### PR TITLE
Adding react-tools as dev dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "protractor": "^1.4.0",
     "psi": "^0.1.5",
     "react": "^0.12.1",
+    "react-tools": "^0.12.1",
     "run-sequence": "^1.0.1",
     "url-loader": "^0.5.5",
     "webpack": "^1.4.13",


### PR DESCRIPTION
Right now `gulp` failes if `react-tools` isn't installed globally. I feel it should either 
1) Be declared as a dev dep, as per this PR
or
2) Gulp task should try/catch the `require('react-tools')` and throw an error if it isn't found.

I know they recommend to install `react-tools` globally, but I haven't experienced any problems running it with a local installation
