### PR TITLE
Setting page description and title based on state from PageStore

### DIFF
--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -19,7 +19,8 @@ var Navbar = require('../components/Navbar');
  */
 function getState() {
   return {
-    title: PageStore.get().title
+    title: PageStore.get().title,
+    description: PageStore.get().description
   };
 }
 
@@ -44,8 +45,8 @@ var DefaultLayout = React.createClass({
     ) : (
       <div className="jumbotron">
         <div className="container text-center">
-          <h1>React</h1>
-          <p>Complex web apps made easy</p>
+          <h1>{this.state.title}</h1>
+          <p>{this.state.description}</p>
         </div>
       </div>
     );

--- a/src/pages/Index.js
+++ b/src/pages/Index.js
@@ -20,6 +20,7 @@ var HomePage = React.createClass({
 
   componentWillMount() {
     PageActions.set({title: 'React.js Starter Kit'});
+    PageActions.set({description: 'Complex web apps made easy'});
   },
 
   render() {


### PR DESCRIPTION
Doesn't make sense that the header title/description in the DefaultLayout is static..
