### PR TITLE
Updated less-loader dependency to 2.0.0 – fixes #42

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jshint-stylish": "^1.0.0",
     "jsx-loader": "^0.12.2",
     "less": "^2.1.1",
-    "less-loader": "^0.7.8",
+    "less-loader": "^2.0.0",
     "merge-stream": "^0.1.6",
     "minimist": "^1.1.0",
     "protractor": "^1.5.0",


### PR DESCRIPTION
Hi,

less-loader has been updated to version 2.0.0.
This solves the error in #42 

Thanks!
