### PR TITLE
Remove extraneous return in PageStore dispatcher callback.

### DIFF
--- a/src/stores/PageStore.js
+++ b/src/stores/PageStore.js
@@ -42,8 +42,6 @@ PageStore.dispatcherToken = Dispatcher.register(payload => {
     PageStore.emitChange();
   }
 
-  return true; // No errors.  Needed by promise in Dispatcher.
-
 });
 
 module.exports = PageStore;


### PR DESCRIPTION
The dispatcher released by facebook (and included in this starter kit) doesn't use promises and doesn't use the return value of registered stores' dispatcher callbacks.

See https://github.com/facebook/flux/blob/master/src/Dispatcher.js#L220 and https://github.com/facebook/flux/blob/master/examples/flux-chat/js/stores/MessageStore.js#L108-134 for some Facebook evidence that this is no longer necessary (unfortunately they haven't been keeping the flux tutorial up-to-date).
