### PR TITLE
Stops browsersync from opening

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,9 @@ gulp.task('serve', function(cb) {
         https: false,
         // Informs browser-sync to proxy our Express app which would run
         // at the following location
-        proxy: 'http://localhost:5000'
+        proxy: 'http://localhost:5000',
+
+        open: false
       });
 
       process.on('exit', function () {


### PR DESCRIPTION
browsersync insists on opening localhost:3000 which is not where the app is at.