### PR TITLE
Use ESLint Loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "css-loader": "^0.9.1",
     "del": "^1.1.1",
     "eslint": "^0.15.1",
+    "eslint-loader": "^0.4.0",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-cache": "^0.2.8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ var config = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'jshint'
+        loader: 'eslint-loader'
       }
     ],
 


### PR DESCRIPTION
Hey thanks for this project!

#71 switched JSHint out for ESLint, but did not update the webpack loader. The `gulp bundle` task was failing silently. This change restores bundling by using `eslint-loader`.