### PR TITLE
Fix output.publicPath in wepback.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ var GLOBALS = {
 var config = {
   output: {
     path: './build/',
-    publicPath: './build/',
+    publicPath: './',
     sourcePrefix: '  '
   },
 


### PR DESCRIPTION
Changed output.publicPath from './build/' to './'

Images referenced in CSS by the 'url' statement were improperly getting referenced with '/build/' prepended to the file path. Removing changing to './' fixes the problem