### PR TITLE
Update BrowserSync logging prefix to `RSK`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -168,6 +168,7 @@ gulp.task('sync', ['serve'], function(cb) {
   browserSync = require('browser-sync');
 
   browserSync({
+    logPrefix: 'RSK',
     notify: false,
     // Run as an https by setting 'https: true'
     // Note: this uses an unsigned certificate which on first access


### PR DESCRIPTION
In the same way that Google's Web Starter Kit does, you can easily remove the unfortunate `BS` acronym from the BrowserSync CLI output.

My PR proposes that you change the `logPrefix` to `RSK` as seen below:

![RSK](https://s3.amazonaws.com/f.cl.ly/items/2d2c0p2z1Q3B0N2h3t2R/Screen%20Shot%202015-04-08%20at%2010.14.01.png)