### PR TITLE
Fixes gulp race condition

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,11 +56,14 @@ gulp.task('bundle', function(cb) {
   var config = require('./webpack.config.js');
   var bundler = webpack(config);
   var verbose = !!argv.verbose;
+  var numBundled = 0;
 
   function bundle(err, stats) {
     if (err) {
       throw new $.util.PluginError('webpack', err);
     }
+
+    numBundled++;
 
     console.log(stats.toString({
       colors: $.util.colors.supportsColor,
@@ -73,7 +76,7 @@ gulp.task('bundle', function(cb) {
       cachedAssets: verbose
     }));
 
-    if (!started) {
+    if (!started && numBundled >= config.length) {
       started = true;
       return cb();
     }


### PR DESCRIPTION
I ran into a race condition when trimming down the provided application.  If the frontend
bundle finished far enough ahead of the server, the server would fail to start (as that
bundle had not finished processing).

This PR waits for all configs to be bundled before moving onto the next step and solves
this race condition.

Minimal application that triggered the error is in my fork of the repo:
https://github.com/seriallos/react-starter-kit-minimal