### PR TITLE
Removed unnecessary page load at client boot

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,8 @@ let onSetMeta = (name, content) => {
 };
 
 function run() {
+  FastClick.attach(document.body);
+	
   // Render the top-level React component
   let props = {
     path: path,
@@ -48,15 +50,10 @@ function run() {
   });
 }
 
-// Run the application when both DOM is ready
-// and page content is loaded
-Promise.all([
-  new Promise((resolve) => {
-    if (window.addEventListener) {
-      window.addEventListener('DOMContentLoaded', resolve);
-    } else {
-      window.attachEvent('onload', resolve);
-    }
-  }).then(() => FastClick.attach(document.body)),
-  new Promise((resolve) => AppActions.loadPage(path, resolve))
-]).then(run);
+new Promise((resolve) => {
+  if (window.addEventListener) {
+    window.addEventListener('DOMContentLoaded', resolve);
+  } else {
+    window.attachEvent('onload', resolve);
+  }
+}).then(run);


### PR DESCRIPTION
According to [React.renderToString()](https://facebook.github.io/react/docs/top-level-api.html#react.rendertostring) : 
> If you call React.render() on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.

There is no more unnecessary request for initial page.