### PR TITLE
Document Uglify warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ $ gulp build                    # or, `gulp build --release`
 ```
 
 By default, it builds in debug mode. If you need to build in release mode, add
-`--release` flag.
+`--release` flag.  This will minimize your JavaScript; you will also see some warnings from
+[uglify](https://github.com/mishoo/UglifyJS) where it removes unused code from your release.
 
 ### How to Run
 


### PR DESCRIPTION
The `gulp build --release` creates a few hundred warnings from Uglify; add some documentation to keep surprises low.

The warnings are generally dead code removal, e.g.,:

   WARNING in (undefined) app.js from UglifyJs 
   Condition always false [./~/react/lib/invariant.js:26,0]
  Dropping unreachable code [./~/react/lib/invariant.js:27,0]
  ...
  Dropping unused function defineWarningProperty [./~/react/lib/ReactElement.js:32,0]
  ...