### PR TITLE
fix issues #152 and #159

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 node_modules
 npm-debug.log
+.idea/

--- a/src/actions/AppActions.js
+++ b/src/actions/AppActions.js
@@ -4,24 +4,32 @@ import http from 'superagent';
 import { canUseDOM } from 'react/lib/ExecutionEnvironment';
 import Dispatcher from '../core/Dispatcher';
 import ActionTypes from '../constants/ActionTypes';
+import DefaultComponents from '../content/DefaultComponents';
 
 export default {
 
-  navigateTo(path, options) {
-    this.loadPage(path, () => {
-      if (canUseDOM) {
-        if (options && options.replace) {
-          window.history.replaceState({}, document.title, path);
-        } else {
-          window.history.pushState({}, document.title, path);
-        }
+  goToPath(path, options) {
+    if (canUseDOM) {
+      if (options && options.replace) {
+        window.history.replaceState({}, document.title, path);
+      } else {
+        window.history.pushState({}, document.title, path);
       }
+    }
 
-      Dispatcher.dispatch({
-        type: ActionTypes.CHANGE_LOCATION,
-        path
-      });
+    Dispatcher.dispatch({
+      type: ActionTypes.CHANGE_LOCATION,
+      path
     });
+  },
+
+  navigateTo(path, options) {
+    // don't load the page if you don't have to
+    if (DefaultComponents[path]) {
+      this.goToPath(path, options);
+    } else {
+      this.loadPage(path, this.goToPath.bind(this, path, options));
+    }
   },
 
   loadPage(path, cb) {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -40,27 +40,8 @@ class App {
   render() {
     let component;
 
-    switch (this.props.path) {
-
-      case '/':
-      case '/about':
-      case '/privacy':
-        let page = AppStore.getPage(this.props.path);
-        component = React.createElement(pages[page.component], page);
-        break;
-
-      case '/contact':
-        component = <ContactPage />;
-        break;
-
-      case '/login':
-        component = <LoginPage />;
-        break;
-
-      case '/register':
-        component = <RegisterPage />;
-        break;
-    }
+    let page = AppStore.getPage(this.props.path);
+    component = page ? React.createElement(pages[page.component], page) : null;
 
     return component ? (
       <div>

--- a/src/content/DefaultComponents.js
+++ b/src/content/DefaultComponents.js
@@ -1,0 +1,10 @@
+/*! React Starter Kit | MIT License | http://www.reactstarterkit.com/ */
+
+// these routes do not need a server request to render its component
+
+var paths = {};
+paths['/login'] = 'LoginPage';
+paths['/contact'] = 'ContactPage';
+paths['/register'] = 'RegisterPage';
+
+export default paths;

--- a/src/server.js
+++ b/src/server.js
@@ -31,10 +31,13 @@ const template = _.template(fs.readFileSync(templateFile, 'utf8'));
 
 server.get('*', async (req, res, next) => {
   try {
-    // TODO: Temporary fix #159
-    if (['/', '/about', '/privacy'].indexOf(req.path) !== -1) {
-      await db.getPage(req.path);
-    }
+    await db.getPage(req.path).catch(async (err) => {
+      if (err.code !== 'ENOENT') {
+        console.error('Error: ', err);
+      }
+      await db.getPage('/');
+    });
+
     let notFound = false;
     let css = [];
     let data = {description: ''};
@@ -48,6 +51,7 @@ server.get('*', async (req, res, next) => {
       }} />);
 
     data.body = React.renderToString(app);
+
     data.css = css.join('');
     let html = template(data);
     if (notFound) {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -3,10 +3,18 @@
 import EventEmitter from 'eventemitter3';
 import Dispatcher from '../core/Dispatcher';
 import ActionTypes from '../constants/ActionTypes';
+import DefaultComponents from '../content/DefaultComponents';
 
 const CHANGE_EVENT = 'change';
 
 var pages = {};
+Object.keys(DefaultComponents).forEach(path => {
+  pages[path] = {
+    component: DefaultComponents[path],
+    path: path
+  };
+});
+
 var loading = false;
 
 var AppStore = Object.assign({}, EventEmitter.prototype, {


### PR DESCRIPTION
This seems to resolve issues #152 and #159 while removing unnecessary calls to the server for pages without content (Contact, Login, Register, NotFound)

1. Added a DefaultComponents file, which provides a dictionary indicating pages that do not require a HTTP request
2. Updated AppActions.js (the action creator) to prevent making a GET request if the path exists in the DefaultComponents dictionary
3. Updated AppStore.js, the pages dictionary is now initialized to contain the paths that do not require a HTTP request. These paths now map to a default page object for App.js to use without throwing an error.
4. Updated App.js, replaced the switch statement with a call to the AppStore
5. Refactored Database.js and server.js
    * I borrowed the code from vachix's [pull request 161](https://github.com/kriasoft/react-starter-kit/pull/161)