### PR TITLE
Update support section and add live help sessions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ the file is. Name the test by appending `-test.js` to the js file.
 
 ### Support
 
-Have feedback, feature request or need help? Contact me on [codementor.io/koistya](https://www.codementor.io/koistya).
+ * [@koistya](https://www.codementor.io/koistya) on Codementor
+ * [#react-starter-kit](https://gitter.im/kriasoft/react-starter-kit) on Gitter
+ * [Live help sessions](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-starter-kit) on Thinkful
 
 ### Copyright
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](http://img.shields.io/travis/kriasoft/react-starter-kit/master.svg?style=flat-square)](http://travis-ci.org/kriasoft/react-starter-kit)
 [![Dependency Status](https://david-dm.org/kriasoft/react-starter-kit.svg?style=flat-square)](https://david-dm.org/kriasoft/react-starter-kit)
 [![Gitter](http://img.shields.io/badge/chat_room-online-brightgreen.svg?style=flat-square)](https://gitter.im/kriasoft/react-starter-kit)
+[![Pair on this](https://tf-assets-staging.s3.amazonaws.com/badges/thinkful_repo_badge.svg)](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-starter-kit)
 [![Tips](http://img.shields.io/gratipay/koistya.svg?style=flat-square)](https://gratipay.com/koistya)
 
 > This project template is a skeleton for an [isomorphic](http://nerds.airbnb.com/isomorphic-javascript-future-web-apps/)


### PR DESCRIPTION
Hi @koistya — as discussed over email, updated the README so that the support section matches https://github.com/kriasoft/babel-starter-kit, and added Thinkful's open pairing sessions badge next to Gitter.