### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 │   ├── /utils/                 # Utility classes and functions
 │   ├── /app.js                 # Client-side startup script
 │   └── /server.js              # Server-side startup script
-│── gulpfile.js                 # Configuration file for automated builds
+│── gulpfile.babel.js           # Configuration file for automated builds
 │── package.json                # The list of 3rd party libraries and utilities
 │── preprocessor.js             # ES6 transpiler settings for Jest
 └── webpack.config.js           # Webpack configuration for bundling and optimization
@@ -90,7 +90,7 @@ $ gulp build --release          # Builds the project in release mode
 $ gulp deploy                   # or, `gulp deploy --production`
 ```
 
-For more information see `deploy` task in `gulpfile.js`.
+For more information see `deploy` task in `gulpfile.babel.js`.
 
 ### How to Update
 


### PR DESCRIPTION
The name of of Gulp configuration file was changed in commit 21e5e7eac92f99838f9a40da7bfeaf6cfeb3c7e9 from `gulpfile.js` to `gulpfile.babel.js`. However, the README file still states that "For more information see `deploy` task in `gulpfile.js`".