### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "browser-sync": "^2.8.2",
     "css-loader": "^0.15.6",
     "csscomb": "^3.1.8",
-    "cssnext": "^1.8.2",
+    "cssnext": "^1.8.3",
     "del": "^1.2.0",
     "eslint": "^1.0.0",
     "eslint-loader": "^0.14.2",


### PR DESCRIPTION
When `gulp build` started error had happened (Ubuntu 14.04.2 x32, node 0.12.7).
Latest version of cssnext solve this problem.