### PR TITLE
Fixing #196 and adding 'dotenv' support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 node_modules
 npm-debug.log
+.env

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cssnext": "^1.8.3",
     "del": "^1.2.0",
     "eslint": "^1.0.0",
-    "eslint-loader": "^0.14.2",
+    "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.0",
     "git-push": "^0.1.1",
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "babel": "5.8.21",
     "classnames": "2.1.3",
+    "dotenv": "^1.2.0",
     "eventemitter3": "1.1.1",
     "express": "4.13.3",
     "fastclick": "1.0.6",

--- a/src/server.js
+++ b/src/server.js
@@ -1,12 +1,18 @@
 /*! React Starter Kit | MIT License | http://www.reactstarterkit.com/ */
 
 import 'babel/polyfill';
+import dotenv from 'dotenv';
 import _ from 'lodash';
 import fs from 'fs';
 import path from 'path';
 import express from 'express';
 import ReactDOM from 'react-dom/server';
 import router from './router';
+
+//
+// Load environment variables from .env
+// ----------------------------------------------------------------------------
+if (fs.existsSync('.env')) dotenv.load();
 
 const server = global.server = express();
 


### PR DESCRIPTION
Installed react-starter-kit today and ran into two issues that I'm thinking should potentially be fixed/included:
- Issue #196 for which there was as suggested solution.
- Was hoping to be able to control the PORT via a .env file so I added support.
