### PR TITLE
Update the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Join [#react-starter-kit](https://gitter.im/kriasoft/react-starter-kit) chatroom
 ├── /tools/                     # Build automation scripts and utilities
 │   ├── /lib/                   # Library for utility snippets
 │   ├── /build.js               # Builds the project from source to output (build) folder
-│   ├── /bundle.js              # Bundles the web resources into package(s) through webpack
+│   ├── /bundle.js              # Bundles the web resources into package(s) through Webpack
 │   ├── /clean.js               # Cleans up the output (build) folder
 │   ├── /config.js              # Webpack configuration for both client and server side bundles
 │   ├── /copy.js                # Copies static files to output (build) folder
 │   ├── /serve.js               # Launches the Node.js/Express web server in a seperate process
 │   ├── /start.js               # Launches the development web server with "live reload" functionality
-│   └── /(deploy.js)            # Deploys your webapp (Planned)
+│   └── /(deploy.js)            # Deploys your web application (Planned)
 │── package.json                # The list of 3rd party libraries and utilities
 └── preprocessor.js             # ES6 transpiler settings for Jest
 ```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ Join [#react-starter-kit](https://gitter.im/kriasoft/react-starter-kit) chatroom
 │   ├── /app.js                 # Client-side startup script
 │   └── /server.js              # Server-side startup script
 ├── /tools/                     # Build automation scripts and utilities
+│   ├── /lib/                   # Library for utility snippets
+│   ├── /build.js               # Builds the project from source to output (build) folder
+│   ├── /bundle.js              # Bundles the web resources into package(s) through webpack
+│   ├── /clean.js               # Cleans up the output (build) folder
+│   ├── /config.js              # Webpack configuration for both client and server side bundles
+│   ├── /copy.js                # Copies static files to output (build) folder
+│   ├── /serve.js               # Launches the Node.js/Express web server in a seperate process
+│   ├── /start.js               # Launches the development web server with "live reload" functionality
+│   └── /(deploy.js)            # Deploys your webapp (Planned)
 │── package.json                # The list of 3rd party libraries and utilities
-│── preprocessor.js             # ES6 transpiler settings for Jest
-└── webpack.config.js           # Webpack configuration for bundling and optimization
+└── preprocessor.js             # ES6 transpiler settings for Jest
 ```
 
 ### Getting Started


### PR DESCRIPTION
Added explanations to the tools folder and removed the deprecated 'webpack.config.js' which is no longer there.  The deploy.js is not implemented by default so I added an explanation. This change should make the react-starter-kit easier to understand as of the current version.