### PR TITLE
Use global.WATCH instead of global.watch

### DIFF
--- a/tools/bundle.js
+++ b/tools/bundle.js
@@ -31,7 +31,7 @@ export default async () => new Promise((resolve, reject) => {
     }
   }
 
-  if (global.watch) {
+  if (global.WATCH) {
     bundler.watch(200, bundle);
   } else {
     bundler.run(bundle);


### PR DESCRIPTION
global.WATCH is defined in start.js 
```js
global.WATCH = true;
````

global.watch is `undefined`.