### PR TITLE
Modified incorrect usage of Jade API & var names

### DIFF
--- a/src/api/content.js
+++ b/src/api/content.js
@@ -11,9 +11,10 @@ const CONTENT_DIR = join(__dirname, './content');
 
 // Extract 'front matter' metadata and generate HTML
 const parseJade = (path, jadeContent) => {
-  const content = fm(jadeContent);
-  const html = jade.render(content.body, null, '  ');
-  const page = Object.assign({ path, content: html }, content.attributes);
+  const fmContent = fm(jadeContent);
+  const jadeOptions = null; // TODO: Modify the parseJade to allow dynamic render option for Jade?
+  const htmlContent = jade.render(fmContent.body, jadeOptions);
+  const page = Object.assign({ path, content: htmlContent }, fmContent.attributes);
   return page;
 };
 

--- a/src/api/content.js
+++ b/src/api/content.js
@@ -12,7 +12,7 @@ const CONTENT_DIR = join(__dirname, './content');
 // Extract 'front matter' metadata and generate HTML
 const parseJade = (path, jadeContent) => {
   const fmContent = fm(jadeContent);
-  const jadeOptions = null; // TODO: Modify the parseJade to allow dynamic render option for Jade?
+  const jadeOptions = null; // TODO: Modify the parseJade function to allow dynamic render options for Jade?
   const htmlContent = jade.render(fmContent.body, jadeOptions);
   const page = Object.assign({ path, content: htmlContent }, fmContent.attributes);
   return page;


### PR DESCRIPTION
Change 1:
according to:
http://jade-lang.com/api/

The current Jade API for render method is:
jade.render(source, options) which only accepts two parameters.

Change 2:
Modified variable names so that they better fit their intended meanings.