### PR TITLE
Reference case-sesnsitive global.WATCH for webpack config

### DIFF
--- a/tools/bundle.js
+++ b/tools/bundle.js
@@ -26,7 +26,7 @@ export default async () => new Promise((resolve, reject) => {
 
     console.log(stats.toString(config[0].stats));
 
-    if (++bundlerRunCount === (global.watch ? config.length : 1)) {
+    if (++bundlerRunCount === (global.WATCH ? config.length : 1)) {
       return resolve();
     }
   }


### PR DESCRIPTION
This appeared to be causing an issue in projects where an extra webpack config item exists.

For example, if I have `widgetConfig` in addition to `appConfig` and `serverConfig`:

```
export default [widgetConfig, appConfig, serverConfig];
```

`npm start` would bundle widget.js first but then fail because server.js was not bundled yet

```
bundle
Container#eachAtRule is deprecated. Use Container#walkAtRules instead.
Container#eachRule is deprecated. Use Container#walkRules instead.
Container#eachDecl is deprecated. Use Container#walkDecls instead.
Node#removeSelf is deprecated. Use Node#remove.
Time: 7238ms
        Asset    Size  Chunks             Chunk Names
    widget.js  745 kB       0  [emitted]  main
widget.js.map  864 kB       0  [emitted]  main
serve
module.js:338
    throw err;
          ^
Error: Cannot find module '/Users/dev/Desktop/project/build/server.js'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
Time: 7623ms
```

After referencing `global.WATCH` instead of `gobal.watch`, things start working again
