### PR TITLE
Update Link.js

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -44,7 +44,7 @@ class Link extends Component {
         this.props && this.props.state || null,
         this.props && this.props.to || (link.pathname + link.search));
     }
-  };
+  }
 
   render() {
     const { to, children, ...props } = this.props;

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -20,7 +20,7 @@ class Link extends Component {
     onClick: PropTypes.func,
   };
 
-  static handleClick = event => {
+  static handleClick(event) {
     let allowTransition = true;
     let clickResult;
 


### PR DESCRIPTION
When rendering a Link component, the binding to handleClick doesn't work due to some weirdness with static methods and the arrow function. I've tested and it works as a regular static method definition for both static invocation of Link.handleClick.bind in other components, as well as in the rendering of the Link component.

[Stack Overflow Discussion](http://stackoverflow.com/questions/32825754/how-to-force-react-es6-static-methods-this-to-be-bound-to-lexical-scope)