### PR TITLE
don't use lambda function for handleClick

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -20,7 +20,7 @@ class Link extends Component {
     onClick: PropTypes.func,
   };
 
-  static handleClick = event => {
+  static handleClick(event) {
     let allowTransition = true;
     let clickResult;
 


### PR DESCRIPTION
Otherwise, the function doesn’t have access to this.props if one
chooses to use this method: `<Link to="/about"><span>About</span></Link>`