### PR TITLE
Bugfix: keep port of server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,7 @@ import Html from './components/Html';
 
 const server = global.server = express();
 const port = process.env.PORT || 5000;
+server.set('port', port);
 
 //
 // Register Node.js middleware


### PR DESCRIPTION
`port` attribute is still being used in https://github.com/kriasoft/react-starter-kit/blob/master/src/core/HttpClient.js#L13

Can't start the server now with `npm start`