### PR TITLE
Scoped packages in webpack server externals

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -180,7 +180,7 @@ const serverConfig = merge({}, config, {
   externals: [
     function filter(context, request, cb) {
       const isExternal =
-        request.match(/^[a-z][a-z\/\.\-0-9]*$/i) &&
+        request.match(/^[@a-z][a-z\/\.\-0-9]*$/i) &&
         !request.match(/^react-routing/) &&
         !context.match(/[\\/]react-routing/);
       cb(null, Boolean(isExternal));


### PR DESCRIPTION
Added an @ character to the check for a package name in the webpack server config externals section. This allows me to correctly include my private scoped package `@alastair/mybrand.lib`.