### PR TITLE
eslint is complaining about es7 features such as decorators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb",
   "globals": {
     "__DEV__": true


### PR DESCRIPTION
eslint is complaining about decorators and static properties.
When including the babel-eslint parser, everything seems to work properly. 

Air-bnb-config removed the parser from in version 1.0.0:

>1.0.0
- removes `babel-eslint` dependency