### PR TITLE
add query parameters available in router

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -37,7 +37,7 @@ server.get('*', async (req, res, next) => {
       onPageNotFound: () => statusCode = 404,
     };
 
-    await Router.dispatch({ path: req.path, context }, (state, component) => {
+    await Router.dispatch({ path: req.path, query: req.query, context }, (state, component) => {
       data.body = ReactDOM.renderToString(component);
       data.css = css.join('');
     });


### PR DESCRIPTION
query parameters are not available in router. It's just a quick fix proposed by @Bogdan in https://github.com/kriasoft/react-routing/issues/18