### PR TITLE
Use Link component instead of <a> tags

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -21,11 +21,11 @@ class Footer extends Component {
         <div className={s.container}>
           <span className={s.text}>© Your Company</span>
           <span className={s.spacer}>·</span>
-          <a className={s.link} href="/" onClick={Link.handleClick}>Home</a>
+          <Link className={s.link} to="/">Home</Link>
           <span className={s.spacer}>·</span>
-          <a className={s.link} href="/privacy" onClick={Link.handleClick}>Privacy</a>
+          <Link className={s.link} to="/privacy">Privacy</Link>
           <span className={s.spacer}>·</span>
-          <a className={s.link} href="/not-found" onClick={Link.handleClick}>Not Found</a>
+          <Link className={s.link} to="/not-found">Not Found</Link>
         </div>
       </div>
     );

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -21,10 +21,10 @@ class Header extends Component {
       <div className={s.root}>
         <div className={s.container}>
           <Navigation className={s.nav} />
-          <a className={s.brand} href="/" onClick={Link.handleClick}>
+          <Link className={s.brand} to="/">
             <img src={require('./logo-small.png')} width="38" height="38" alt="React" />
             <span className={s.brandTxt}>Your Company</span>
-          </a>
+          </Link>
           <div className={s.banner}>
             <h1 className={s.bannerTitle}>React</h1>
             <p className={s.bannerDesc}>Complex web apps made easy</p>

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -23,12 +23,12 @@ class Navigation extends Component {
   render() {
     return (
       <div className={cx(s.root, this.props.className)} role="navigation">
-        <a className={s.link} href="/about" onClick={Link.handleClick}>About</a>
-        <a className={s.link} href="/contact" onClick={Link.handleClick}>Contact</a>
+        <Link className={s.link} to="/about">About</Link>
+        <Link className={s.link} to="/contact">Contact</Link>
         <span className={s.spacer}> | </span>
-        <a className={s.link} href="/login" onClick={Link.handleClick}>Log in</a>
+        <Link className={s.link} to="/login">Log in</Link>
         <span className={s.spacer}>or</span>
-        <a className={cx(s.link, s.highlight)} href="/register" onClick={Link.handleClick}>Sign up</a>
+        <Link className={cx(s.link, s.highlight)} to="/register">Sign up</Link>
       </div>
     );
   }


### PR DESCRIPTION
There wasn't an obvious reason to me why `<a>` tags were used manually instead of `<a>` tags. This ends up making things a bit shorter since there's no need to bind the `Link` click handler each time.