### PR TITLE
Add classname module for proper concatination several classes

### DIFF
--- a/docs/react-style-guide.md
+++ b/docs/react-style-guide.md
@@ -122,10 +122,11 @@ Navigation.propTypes = { items: PropTypes.array.isRequired };
 import React, { PropTypes } from 'react';
 import s from './Navigation.scss';
 import withStyles from '../../decorators/withStyles';
+import cx from 'classnames';
 
 function Navigation() {
   return (
-    <nav className={[s.root, this.props.className]}>
+    <nav className={cx([s.root, this.props.className])}>
       <ul className={s.items}>
         <li className={[s.item, s.selected]}>
           <a className={s.link} href="/products">Products</a>


### PR DESCRIPTION
Without `cx` following line
```
<nav className={[s.root, this.props.className])>
```
became improper separated via comma in html
```
<nav class="root_e4f,some_lass_d6e">
```