### PR TITLE
Prevent `precss` upgrade to 1.4.0 (breaks webpack build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss": "^5.0.13",
     "postcss-import": "^7.1.3",
     "postcss-loader": "^0.8.0",
-    "precss": "^1.3.0",
+    "precss": "1.3.0",
     "raw-loader": "^0.5.1",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",


### PR DESCRIPTION
`precss` @ 1.4.0 breaks the webpack build. Version 1.4.0 was [committed](https://github.com/jonathantneal/precss/commit/526e3048f127ecf378f4f120749ad3d954cd8726) back in October, but was published on 12/31/15 as you can see below:
```bash
$ npm view precss@1.4.0 time
 ```
```
{ modified: '2015-12-31T16:10:58.660Z',
  created: '2015-07-08T13:50:20.870Z',
  '0.1.0': '2015-07-08T13:50:20.870Z',
  '0.1.1': '2015-07-08T20:14:37.697Z',
  '0.1.2': '2015-07-08T20:24:00.490Z',
  '0.1.3': '2015-07-08T21:04:08.303Z',
  '0.2.0': '2015-07-10T05:07:08.988Z',
  '0.2.1': '2015-07-10T15:50:03.162Z',
  '0.2.2': '2015-07-10T15:58:03.292Z',
  '0.3.0': '2015-07-22T20:03:49.866Z',
  '1.0.0': '2015-09-07T05:27:41.581Z',
  '1.1.0': '2015-09-08T18:04:36.432Z',
  '1.1.1': '2015-09-08T18:20:06.091Z',
  '1.1.2': '2015-09-08T19:52:27.209Z',
  '1.1.3': '2015-09-14T04:00:18.530Z',
  '1.2.0': '2015-09-24T11:49:55.270Z',
  '1.2.1': '2015-09-24T12:04:33.232Z',
  '1.2.2': '2015-09-24T12:06:55.036Z',
  '1.2.3': '2015-09-24T18:55:30.897Z',
  '1.3.0': '2015-10-22T02:56:14.527Z',
  '1.4.0': '2015-12-31T16:10:58.660Z' }
```