### PR TITLE
Remove `history.createHref` deprecation notices

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fastclick": "1.0.6",
     "fbjs": "0.5.1",
     "front-matter": "2.0.1",
-    "history": "1.16.0",
+    "history": "1.17.0",
     "jade": "1.11.0",
     "node-fetch": "1.3.3",
     "normalize.css": "3.0.3",


### PR DESCRIPTION
Deprecation notices were accidentally put into `history@1.16.0` and removed in  `history@1.17.0`
https://github.com/rackt/history/commit/eb1c1c5d6368f736bab0460da76581275bf0fda3.

Example deprecation notice:
`Warning: the query argument to createHref is deprecated; use a location descriptor instead`