### PR TITLE
Disable Browsersync UI and Notifications in `--release` mode

### DIFF
--- a/tools/start.js
+++ b/tools/start.js
@@ -17,6 +17,8 @@ import webpackConfig from './webpack.config';
 import clean from './clean';
 import copy from './copy';
 
+const DEBUG = !process.argv.includes('--release');
+
 /**
  * Launches a development web server with "live reload" functionality -
  * synchronizing URLs, interactions and code changes across multiple devices.
@@ -81,6 +83,8 @@ async function start() {
         if (!err) {
           const bs = Browsersync.create();
           bs.init({
+            notify: DEBUG,
+            ui: DEBUG,
             proxy: {
               target: host,
               middleware: [wpMiddleware, ...hotMiddlewares],

--- a/tools/start.js
+++ b/tools/start.js
@@ -84,7 +84,7 @@ async function start() {
           const bs = Browsersync.create();
           bs.init({
             notify: DEBUG,
-            ui: DEBUG,
+            ui: DEBUG ? { port: 3001 } : false,
             proxy: {
               target: host,
               middleware: [wpMiddleware, ...hotMiddlewares],


### PR DESCRIPTION
This prevents Browsersync UI  and notifications from showing in production.