### PR TITLE
Update package.json: move source-map-support to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react": "0.14.3",
     "react-dom": "0.14.3",
     "react-routing": "0.0.6",
-    "source-map-support": "0.4.0",
     "whatwg-fetch": "0.10.1"
   },
   "devDependencies": {
@@ -58,6 +57,7 @@
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.2.0",
     "replace": "^0.3.0",
+    "source-map-support": "0.4.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",
     "webpack-hot-middleware": "^2.6.0",


### PR DESCRIPTION
`source-map-support` used in webpack which works under dev environment