### PR TITLE
Fixed universal rendering support with material-ui.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,10 @@ server.get('*', async (req, res, next) => {
       onPageNotFound: () => statusCode = 404,
     };
 
+    global.navigator = {
+      userAgent: req.headers['user-agent']
+    };
+
     await Router.dispatch({ path: req.path, query: req.query, context }, (state, component) => {
       data.body = ReactDOM.renderToString(component);
       data.css = css.join('');


### PR DESCRIPTION
The Material UI set of components require that `navigator.userAgent` be defined before rendering styles on the server side.

https://github.com/callemall/material-ui/pull/2007