### PR TITLE
Added missing dependency 'core-js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-runtime": "^6.3.19",
     "bluebird": "3.1.1",
     "classnames": "2.2.3",
+    "core-js": "^2.0.3",
     "eventemitter3": "1.1.1",
     "express": "4.13.3",
     "fastclick": "1.0.6",

--- a/src/components/TextBox/TextBox.js
+++ b/src/components/TextBox/TextBox.js
@@ -26,8 +26,12 @@ class TextBox extends Component {
     return (
       <div className={s.root}>
         {this.props.maxLines > 1 ?
-          <textarea {...this.props} className={s.input} ref="input" key="input" rows={this.props.maxLines} /> :
-          <input {...this.props} className={s.input} ref="input" key="input" />}
+          <textarea {...this.props}
+            className={s.input}
+            ref="input"
+            key="input"
+            rows={this.props.maxLines}
+          /> : <input {...this.props} className={s.input} ref="input" key="input" />}
       </div>
     );
   }


### PR DESCRIPTION
Upon cloning the directory and running `npm install` and `npm start` you receive an error for a missing module:

```
Error: Cannot find module 'core-js/library/fn/is-iterable'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/Users/andrewkishino/Documents/project_templates/react-template/build/webpack:/external "core-js/library/fn/is-iterable":1:1)
    at __webpack_require__ (/Users/andrewkishino/Documents/project_templates/react-template/build/webpack:/webpack/bootstrap 416f15863871a726e916:19:1)
    at Object.<anonymous> (/Users/andrewkishino/Documents/project_templates/react-template/build/webpack:/~/babel-runtime/core-js/is-iterable.js:1:19)
    at __webpack_require__ (/Users/andrewkishino/Documents/project_templates/react-template/build/webpack:/webpack/bootstrap 416f15863871a726e916:19:1)
    at Object.<anonymous> (/Users/andrewkishino/Documents/project_templates/react-template/build/webpack:/~/babel-runtime/helpers/slicedToArray.js:5:1)
    at __webpack_require__ (/Users/andrewkishino/Documents/project_templates/react-template/build/webpack:/webpack/bootstrap 416f15863871a726e916:19:1)
```

The issue is due to 'core-js'  missing from package.json. 