### PR TITLE
Add 'process.env.BROWSER' flag

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -120,7 +120,7 @@ const clientConfig = extend(true, {}, config, {
   // http://webpack.github.io/docs/configuration.html#devtool
   devtool: DEBUG ? 'cheap-module-eval-source-map' : false,
   plugins: [
-    new webpack.DefinePlugin(GLOBALS),
+    new webpack.DefinePlugin({ ...GLOBALS, 'process.env.BROWSER': '"true"' }),
     new AssetsPlugin({
       path: path.join(__dirname, '../build'),
       filename: 'assets.js',
@@ -174,7 +174,7 @@ const serverConfig = extend(true, {}, config, {
   },
   devtool: 'source-map',
   plugins: [
-    new webpack.DefinePlugin(GLOBALS),
+    new webpack.DefinePlugin({ ...GLOBALS, 'process.env.BROWSER': '"false"' }),
     new webpack.BannerPlugin('require("source-map-support").install();',
       { raw: true, entryOnly: false }),
   ],


### PR DESCRIPTION
Universal JavaScript is pretty awesome, but sometimes you just only want to run code in the browser (e.a. JS animation) or on the server. I a `BROWSER` flag to `'process.env`.

```
// Only run code in browser
if (process.env.BROWSER) {
  ...
}
```