### PR TITLE
add required dependency core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "browser-sync": "^2.11.1",
+    "core-js": "^2.1.0",
     "css-loader": "^0.23.1",
     "csscomb": "^3.1.8",
     "del": "^2.2.0",


### PR DESCRIPTION
npm start will return error unless core-js is installed