### PR TITLE
Tell CSS tooling to use all vendor prefixes if the user agent is unknown

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,13 @@ import { port } from './config';
 const server = global.server = express();
 
 //
+// Tell any CSS tooling (such as Material UI) to use all vendor prefixes if the
+// user agent is not known.
+// -----------------------------------------------------------------------------
+global.navigator = global.navigator || {};
+global.navigator.userAgent = global.navigator.userAgent || 'all';
+
+//
 // Register Node.js middleware
 // -----------------------------------------------------------------------------
 server.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
This is a [requirement](http://www.material-ui.com/#/get-started/server-rendering) of Material UI otherwise the user may not get properly styled components.

### Steps to reproduce

With the React Starter Kit, I add Material UI as follows:

    npm install material-ui --save

and the following import to a component:

    import RaisedButton from 'material-ui/lib/raised-button';

and:

    <RaisedButton label="Default" />

I get the following error:

> Warning: Material-UI: userAgent should be supplied in the muiTheme context for server-side rendering.

According to Material UI's documentation, it says I'd need to define the `userAgent`.

### Pull request

This pull request ensures that the `userAgent` is set to `all` if it is not already defined, along with a comment explaining what it is for.
