### PR TITLE
Change default port used to avoid conflict

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@
 /* eslint-disable max-len */
 /* jscs:disable maximumLineLength */
 
-export const port = process.env.PORT || 5000;
+export const port = process.env.PORT || 3000;
 export const host = process.env.WEBSITE_HOSTNAME || `localhost:${port}`;
 
 export const analytics = {

--- a/tools/start.js
+++ b/tools/start.js
@@ -86,6 +86,10 @@ async function start() {
         if (!err) {
           const bs = Browsersync.create();
           bs.init({
+            port: 3001,
+            ui: {
+              port: 3002
+            },
             proxy: {
               target: host,
               middleware: [wpMiddleware, ...hotMiddlewares],


### PR DESCRIPTION
change this port number from 5000 to 3000, so that 3000 is going to be used by Node.js app (server.js), 3001 - BrowserSync, 3002 - BrowserSync UI