### PR TITLE
Add support for markdown and html templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "isomorphic-style-loader": "0.0.10",
     "jade": "1.11.0",
     "jsonwebtoken": "5.7.0",
+    "markdown-it": "^6.0.0",
     "node-fetch": "1.3.3",
     "normalize.css": "3.0.3",
     "passport": "0.3.2",

--- a/src/data/queries/content.js
+++ b/src/data/queries/content.js
@@ -20,13 +20,28 @@ import {
 
 import ContentType from '../types/ContentType';
 
+const md = require('markdown-it')();
+
 // A folder with Jade/Markdown/HTML content pages
 const CONTENT_DIR = join(__dirname, './content');
 
 // Extract 'front matter' metadata and generate HTML
-const parseJade = (path, jadeContent) => {
-  const fmContent = fm(jadeContent);
-  const htmlContent = jade.render(fmContent.body);
+const parseContent = (path, fileContent, extension) => {
+  const fmContent = fm(fileContent);
+  let htmlContent;
+  switch (extension) {
+    case '.jade':
+      htmlContent = jade.render(fmContent.body);
+      break;
+    case '.md':
+      htmlContent = md.render(fmContent.body);
+      break;
+    case '.html':
+      htmlContent = fmContent.body;
+      break;
+    default:
+      return null;
+  }
   return Object.assign({ path, content: htmlContent }, fmContent.attributes);
 };
 
@@ -35,22 +50,52 @@ const fileExists = filename => new Promise(resolve => {
   fs.exists(filename, resolve);
 });
 
+async function resolveExtension(path, extension) {
+  let fileNameBase = join(CONTENT_DIR, `${path === '/' ? '/index' : path}`);
+  let ext = extension;
+  if (!ext.startsWith('.')) {
+    ext = `.${extension}`;
+  }
+
+  let fileName = fileNameBase + ext;
+
+  if (!(await fileExists(fileName))) {
+    fileNameBase = join(CONTENT_DIR, `${path}/index`);
+    fileName = fileNameBase + ext;
+  }
+
+  if (!(await fileExists(fileName))) {
+    return { success: false };
+  }
+
+  return { success: true, fileName };
+}
+
+async function resolveFileName(path) {
+  const extensions = ['.jade', '.md', '.html'];
+
+  for (const extension of extensions) {
+    const maybeFileName = await resolveExtension(path, extension);
+    if (maybeFileName.success) {
+      return { success: true, fileName: maybeFileName.fileName, extension };
+    }
+  }
+
+  return { success: false, fileName: null, extension: null };
+}
+
 export default {
   type: ContentType,
   args: {
     path: { type: new NonNull(StringType) },
   },
   async resolve({ request }, { path }) {
-    let fileName = join(CONTENT_DIR, `${path === '/' ? '/index' : path}.jade`);
-    if (!(await fileExists(fileName))) {
-      fileName = join(CONTENT_DIR, `${path}/index.jade`);
-    }
-
-    if (!(await fileExists(fileName))) {
+    const { success, fileName, extension } = await resolveFileName(path);
+    if (!success) {
       return null;
     }
 
     const source = await readFile(fileName, { encoding: 'utf8' });
-    return parseJade(path, source);
+    return parseContent(path, source, extension);
   },
 };


### PR DESCRIPTION
Adds support for markdown and html template files alongside with jade. 

The code refers to markdown and html already in the comments, but no actual support yet was available.