### PR TITLE
Improve long term caching by adding [chunkhash]

### DIFF
--- a/tools/start.js
+++ b/tools/start.js
@@ -30,21 +30,22 @@ async function start() {
     // Patch the client-side bundle configurations
     // to enable Hot Module Replacement (HMR) and React Transform
     webpackConfig.filter(x => x.target !== 'node').forEach(config => {
+      /* eslint-disable no-param-reassign */
       if (Array.isArray(config.entry)) {
         config.entry.unshift('webpack-hot-middleware/client');
       } else {
-        /* eslint-disable no-param-reassign */
         config.entry = ['webpack-hot-middleware/client', config.entry];
-        /* eslint-enable no-param-reassign */
       }
 
+      config.output.filename = config.output.filename.replace('[chunkhash]', '[hash]');
+      config.output.chunkFilename = config.output.chunkFilename.replace('[chunkhash]', '[hash]');
       config.plugins.push(new webpack.HotModuleReplacementPlugin());
       config.plugins.push(new webpack.NoErrorsPlugin());
       config
         .module
         .loaders
         .filter(x => x.loader === 'babel-loader')
-        .forEach(x => (x.query = { // eslint-disable-line no-param-reassign
+        .forEach(x => (x.query = {
           ...x.query,
 
           // Wraps all React components into arbitrary transforms
@@ -66,6 +67,7 @@ async function start() {
             ],
           ],
         }));
+      /* eslint-enable no-param-reassign */
     });
 
     const bundler = webpack(webpackConfig);


### PR DESCRIPTION
- Use `[chunkhash]` instead of `[hash]` in the names of bundles, it allows to save the bundle name if the content hasn't changed
- Deduplicate assets, use the same `output.path` for files, fix #362
- Use `path.resolve` everywhere in webpack config for consistency
- Use `OccurrenceOrderPlugin` in debug mode too for [hot reload needs](https://github.com/glenjamin/webpack-hot-middleware#installation--usage)
- Move generated (compiled) files from `public` to `public/assets` to not be mixed with other files like static html