### PR TITLE
Force sourcemaps pragma to #

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -201,7 +201,7 @@ const clientConfig = extend(true, {}, config, {
 
   // Choose a developer tool to enhance debugging
   // http://webpack.github.io/docs/configuration.html#devtool
-  devtool: DEBUG ? 'cheap-module-eval-source-map' : false,
+  devtool: DEBUG ? '#cheap-module-eval-source-map' : false,
 });
 
 //


### PR DESCRIPTION
Current console output in Chrome Canary
![image](https://cloud.githubusercontent.com/assets/2155545/13768147/6f4cf8bc-eaad-11e5-86a8-48f031839c56.png)

Modified webpack config to force # pragma

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kriasoft/react-starter-kit/503)

<!-- Reviewable:end -->
