### PR TITLE
fix(test): add core-js to unmockedModulePathPatterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     },
     "unmockedModulePathPatterns": [
       "react",
-      "enzyme"
+      "enzyme",
+      "core-js"
     ]
   },
   "stylelint": {


### PR DESCRIPTION
This seems to solve the issue seen in #491. I don't see any reason why `core-js` should need to be mocked.