### PR TITLE
Adds a hint for a problem with autoreloading when Webstorm "safe write" feature is enabled

### DIFF
--- a/docs/how-to-configure-text-editors.md
+++ b/docs/how-to-configure-text-editors.md
@@ -25,6 +25,8 @@ Enable **CSSComb** by installing CSSReorder plug-in
 
 ![csscomb-in-webstorm](https://dl.dropboxusercontent.com/u/16006521/react-starter-kit/webstorm-csscomb.png)
 
+**If you have trouble with autoreloading** try to disable "safe write" in `File > Settings > System Settings > Use "safe write" (save chnages to a temporary file first)`
+
 ### Atom
 
 Install atom packages


### PR DESCRIPTION
![disable safe save](https://cloud.githubusercontent.com/assets/1221226/13969348/9892ab92-f082-11e5-9688-30c97d3da9e0.png)

Autoreload functionality is not picking up file changes when Webstorm "safe write" feature is enabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kriasoft/react-starter-kit/528)
<!-- Reviewable:end -->
