### PR TITLE
Make footer and feedback stay bottom

### DIFF
--- a/src/components/Feedback/Feedback.scss
+++ b/src/components/Feedback/Feedback.scss
@@ -12,6 +12,9 @@
 .root {
   background: #f5f5f5;
   color: #333;
+  bottom: 4em;
+  position: absolute;
+  width: 100%;
 }
 
 .container {

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -12,6 +12,10 @@
 .root {
   background: #333;
   color: #fff;
+  bottom: 0;
+  position: absolute;
+  width: 100%;
+  height: 4em;
 }
 
 .container {


### PR DESCRIPTION
When the height of content page is not long enough, footer is pulled a little higher and leaves some spaces under it. I added some lines of css to make it stay bottom.
