### PR TITLE
Fix: AccessToken from facebook saved as String

### DIFF
--- a/src/data/models/UserClaim.js
+++ b/src/data/models/UserClaim.js
@@ -17,7 +17,7 @@ const UserClaim = Model.define('UserClaim', {
   },
 
   value: {
-    type: DataType.INTEGER,
+    type: DataType.STRING,
   },
 
 });


### PR DESCRIPTION
Postgress throws an error because facebook is not returning an Integer.