### PR TITLE
Add --static flag to build script which allows to generate static html for specific routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "bundle": "babel-node tools/run bundle",
     "build": "babel-node tools/run build",
     "deploy": "babel-node tools/run deploy",
+    "render": "babel-node tools/run render",
     "start": "babel-node tools/run start"
   }
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -27,6 +27,7 @@ Flag        | Description
 ----------- | -------------------------------------------------- 
 `--release` | Minimizes and optimizes the compiled output
 `--verbose` | Prints detailed information to the console
+`--static`  | Renders [specified routes](./render.js#L15) as static html files
 
 For example:
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -11,6 +11,7 @@ import run from './run';
 import clean from './clean';
 import copy from './copy';
 import bundle from './bundle';
+import render from './render';
 
 /**
  * Compiles the project from source files into a distributable
@@ -20,6 +21,10 @@ async function build() {
   await run(clean);
   await run(copy);
   await run(bundle);
+
+  if (process.argv.includes('--static')) {
+    await run(render);
+  }
 }
 
 export default build;

--- a/tools/render.js
+++ b/tools/render.js
@@ -1,0 +1,45 @@
+/**
+ * React Starter Kit (https://www.reactstarterkit.com/)
+ *
+ * Copyright © 2014-2016 Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+import runServer from './runServer';
+import fs from './lib/fs';
+import fetch from 'node-fetch';
+import { host } from '../src/config';
+
+// Enter your paths here which you want to render as static
+const routes = [
+  '/',
+  '/contact',
+  '/login',
+  '/register',
+  '/about',
+  '/privacy',
+  '/404', // https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/
+];
+
+async function render() {
+  let server;
+  await new Promise(resolve => (server = runServer(resolve)));
+
+  await routes.reduce((promise, route) => promise.then(async () => {
+    const url = `http://${host}${route}`;
+    const dir = `build/public${route.replace(/[^\/]*$/, '')}`;
+    const name = route.endsWith('/') ? 'index.html' : `${route.match(/[^/]+$/)[0]}.html`;
+    const dist = `${dir}${name}`;
+    const res = await fetch(url);
+    const text = await res.text();
+    await fs.makeDir(dir);
+    await fs.writeFile(dist, text);
+    console.log(`${dist} => ${res.status} ${res.statusText}`);
+  }), Promise.resolve());
+
+  server.kill('SIGTERM');
+}
+
+export default render;

--- a/tools/runServer.js
+++ b/tools/runServer.js
@@ -47,6 +47,7 @@ function runServer(cb) {
 
   server.stdout.on('data', onStdOut);
   server.stderr.on('data', x => process.stderr.write(x));
+  return server;
 }
 
 process.on('exit', () => {


### PR DESCRIPTION
```shell
$ npm run build -- --static --release
```
![Build folder with static html files](https://cloud.githubusercontent.com/assets/640669/15091858/a4bc4e54-145f-11e6-8bfe-7591b3934c4f.png)

refs #61 #156 #260 #634 #635