### PR TITLE
revert to graphql ^0.5.0 to match peer dependency in express-graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fbjs": "0.8.2",
     "front-matter": "2.0.7",
     "graphiql": "0.7.1",
-    "graphql": "0.6.0",
+    "graphql": "^0.5.0",
     "history": "2.1.1",
     "isomorphic-style-loader": "1.0.0",
     "jade": "1.11.0",


### PR DESCRIPTION
Warnings generated by commit https://github.com/kriasoft/react-starter-kit/commit/7b03f0b94381932002dd5642ef26644d159f7de5:

```
npm WARN express-graphql@0.5.1 requires a peer of graphql@^0.5.0 but none was installed.
npm WARN graphiql@0.7.1 requires a peer of graphql@^0.5.0 but none was installed.
npm WARN codemirror-graphql@0.5.0 requires a peer of graphql@^0.5.0 but none was installed.
```

There is a peer dependency in https://github.com/graphql/express-graphql/blob/master/package.json line 75.

Still works locally however when deployed to a vanilla ec2 beanstalk instance it errors out, reverting resolves.