### PR TITLE
Add react-helmet to substitute context.setTitle/setMeta

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "pretty-error": "2.0.0",
     "react": "15.1.0",
     "react-dom": "15.1.0",
+    "react-helmet": "^3.1.0",
     "sequelize": "3.23.2",
     "source-map-support": "0.4.0",
     "sqlite3": "3.1.4",
@@ -144,7 +145,15 @@
     "extends": "stylelint-config-standard",
     "rules": {
       "string-quotes": "single",
-      "selector-pseudo-class-no-unknown": [true, { "ignorePseudoClasses": ["global", "local"] }]
+      "selector-pseudo-class-no-unknown": [
+        true,
+        {
+          "ignorePseudoClasses": [
+            "global",
+            "local"
+          ]
+        }
+      ]
     }
   },
   "scripts": {

--- a/src/client.js
+++ b/src/client.js
@@ -17,23 +17,6 @@ import { addEventListener, removeEventListener } from './core/DOMUtils';
 
 const context = {
   insertCss: styles => styles._insertCss(), // eslint-disable-line no-underscore-dangle
-  setTitle: value => (document.title = value),
-  setMeta: (name, content) => {
-    // Remove and create a new <meta /> tag in order to make it work
-    // with bookmarks in Safari
-    const elements = document.getElementsByTagName('meta');
-    Array.from(elements).forEach((element) => {
-      if (element.getAttribute('name') === name) {
-        element.parentNode.removeChild(element);
-      }
-    });
-    const meta = document.createElement('meta');
-    meta.setAttribute('name', name);
-    meta.setAttribute('content', content);
-    document
-      .getElementsByTagName('head')[0]
-      .appendChild(meta);
-  },
 };
 
 // Restore the scroll position if it was saved into the state

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -19,8 +19,6 @@ class App extends Component {
   static propTypes = {
     context: PropTypes.shape({
       insertCss: PropTypes.func,
-      setTitle: PropTypes.func,
-      setMeta: PropTypes.func,
     }),
     children: PropTypes.element.isRequired,
     error: PropTypes.object,
@@ -28,16 +26,12 @@ class App extends Component {
 
   static childContextTypes = {
     insertCss: PropTypes.func.isRequired,
-    setTitle: PropTypes.func.isRequired,
-    setMeta: PropTypes.func.isRequired,
   };
 
   getChildContext() {
     const context = this.props.context;
     return {
       insertCss: context.insertCss || emptyFunction,
-      setTitle: context.setTitle || emptyFunction,
-      setMeta: context.setMeta || emptyFunction,
     };
   }
 

--- a/src/core/HelmetHelper.js
+++ b/src/core/HelmetHelper.js
@@ -1,0 +1,6 @@
+import Helmet from 'react-helmet';
+
+export function getHeadString() {
+  const helmet = Helmet.rewind();
+  return Object.values(helmet).reduce((prev, next) => prev + next.toString(), '');
+}

--- a/src/routes/contact/Contact.js
+++ b/src/routes/contact/Contact.js
@@ -7,16 +7,17 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './Contact.css';
+import Helmet from 'react-helmet';
 
 const title = 'Contact Us';
 
-function Contact(props, context) {
-  context.setTitle(title);
+function Contact() {
   return (
     <div className={s.root}>
+      <Helmet title={title} />
       <div className={s.container}>
         <h1>{title}</h1>
         <p>...</p>
@@ -24,7 +25,5 @@ function Contact(props, context) {
     </div>
   );
 }
-
-Contact.contextTypes = { setTitle: PropTypes.func.isRequired };
 
 export default withStyles(s)(Contact);

--- a/src/routes/content/Content.js
+++ b/src/routes/content/Content.js
@@ -7,37 +7,27 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './Content.css';
+import Helmet from 'react-helmet';
 
-class Content extends Component {
-
-  static contextTypes = {
-    setTitle: PropTypes.func.isRequired,
-  };
-
-  static propTypes = {
-    path: PropTypes.string.isRequired,
-    content: PropTypes.string.isRequired,
-    title: PropTypes.string,
-  };
-
-  componentWillMount() {
-    this.context.setTitle(this.props.title);
-  }
-
-  render() {
-    return (
-      <div className={s.root}>
-        <div className={s.container}>
-          {this.props.path === '/' ? null : <h1>{this.props.title}</h1>}
-          <div dangerouslySetInnerHTML={{ __html: this.props.content || '' }} />
-        </div>
+function Content(props) {
+  return (
+    <div className={s.root}>
+      <Helmet title={props.title} />
+      <div className={s.container}>
+        {props.path === '/' ? null : <h1>{props.title}</h1>}
+        <div dangerouslySetInnerHTML={{ __html: props.content || '' }} />
       </div>
-    );
-  }
-
+    </div>
+  );
 }
+
+Content.propTypes = {
+  path: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  title: PropTypes.string,
+};
 
 export default withStyles(s)(Content);

--- a/src/routes/error/ErrorPage.js
+++ b/src/routes/error/ErrorPage.js
@@ -10,8 +10,9 @@
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './ErrorPage.css';
+import Helmet from 'react-helmet';
 
-function ErrorPage({ error }, context) {
+function ErrorPage({ error }) {
   let title = 'Error';
   let content = 'Sorry, a critical error occurred on this page.';
   let errorMessage = null;
@@ -23,10 +24,9 @@ function ErrorPage({ error }, context) {
     errorMessage = <pre>{error.stack}</pre>;
   }
 
-  context.setTitle(title);
-
   return (
     <div>
+      <Helmet title={title} />
       <h1>{title}</h1>
       <p>{content}</p>
       {errorMessage}
@@ -35,6 +35,5 @@ function ErrorPage({ error }, context) {
 }
 
 ErrorPage.propTypes = { error: PropTypes.object.isRequired };
-ErrorPage.contextTypes = { setTitle: PropTypes.func.isRequired };
 
 export default withStyles(s)(ErrorPage);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -10,13 +10,19 @@
 import React, { PropTypes } from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './Home.css';
+import Helmet from 'react-helmet';
 
 const title = 'React Starter Kit';
 
-function Home({ news }, context) {
-  context.setTitle(title);
+function Home({ news }) {
   return (
     <div className={s.root}>
+      <Helmet
+        title={title}
+        meta={[
+          { name: 'description', content: 'home' },
+        ]}
+      />
       <div className={s.container}>
         <h1 className={s.title}>React.js News</h1>
         <ul className={s.news}>
@@ -42,6 +48,5 @@ Home.propTypes = {
     contentSnippet: PropTypes.string,
   })).isRequired,
 };
-Home.contextTypes = { setTitle: PropTypes.func.isRequired };
 
 export default withStyles(s)(Home);

--- a/src/routes/login/Login.js
+++ b/src/routes/login/Login.js
@@ -7,16 +7,17 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './Login.css';
+import Helmet from 'react-helmet';
 
 const title = 'Log In';
 
-function Login(props, context) {
-  context.setTitle(title);
+function Login() {
   return (
     <div className={s.root}>
+      <Helmet title={title} />
       <div className={s.container}>
         <h1>{title}</h1>
         <p className={s.lead}>Log in with your username or company email address.</p>
@@ -116,7 +117,5 @@ function Login(props, context) {
     </div>
   );
 }
-
-Login.contextTypes = { setTitle: PropTypes.func.isRequired };
 
 export default withStyles(s)(Login);

--- a/src/routes/register/Register.js
+++ b/src/routes/register/Register.js
@@ -7,16 +7,17 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './Register.css';
+import Helmet from 'react-helmet';
 
 const title = 'New User Registration';
 
-function Register(props, context) {
-  context.setTitle(title);
+function Register() {
   return (
     <div className={s.root}>
+      <Helmet title={title} />
       <div className={s.container}>
         <h1>{title}</h1>
         <p>...</p>
@@ -24,7 +25,5 @@ function Register(props, context) {
     </div>
   );
 }
-
-Register.contextTypes = { setTitle: PropTypes.func.isRequired };
 
 export default withStyles(s)(Register);

--- a/src/server.js
+++ b/src/server.js
@@ -24,6 +24,7 @@ import schema from './data/schema';
 import routes from './routes';
 import assets from './assets'; // eslint-disable-line import/no-unresolved
 import { port, auth, analytics } from './config';
+import { getHeadString } from './core/HelmetHelper';
 
 const app = express();
 
@@ -85,7 +86,7 @@ app.get('*', async (req, res, next) => {
     let css = [];
     let statusCode = 200;
     const template = require('./views/index.jade'); // eslint-disable-line global-require
-    const data = { title: '', description: '', css: '', body: '', entry: assets.main.js };
+    const data = { head: '', css: '', body: '', entry: assets.main.js };
 
     if (process.env.NODE_ENV === 'production') {
       data.trackingId = analytics.google.trackingId;
@@ -96,13 +97,12 @@ app.get('*', async (req, res, next) => {
       query: req.query,
       context: {
         insertCss: styles => css.push(styles._getCss()), // eslint-disable-line no-underscore-dangle
-        setTitle: value => (data.title = value),
-        setMeta: (key, value) => (data[key] = value),
       },
       render(component, status = 200) {
         css = [];
         statusCode = status;
         data.body = ReactDOM.renderToString(component);
+        data.head = getHeadString();
         data.css = css.join('');
         return true;
       },

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -3,10 +3,9 @@ html(class="no-js", lang="")
   head
     meta(charset="utf-8")
     meta(http-equiv="x-ua-compatible", content="ie=edge")
-    title= title
-    meta(name="description", description=description)
     meta(name="viewport", content="width=device-width, initial-scale=1")
     link(rel="apple-touch-icon", href="apple-touch-icon.png")
+    !{head}
     style#css!= css
   body
     #app!= body


### PR DESCRIPTION
By using react-helmet instead of self-implemented setTitle and setMeta, we're able to put more control over head tag.

https://github.com/nfl/react-helmet
