### PR TITLE
Update stylelint-config-standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redbox-react": "^1.2.6",
     "sinon": "^2.0.0-pre",
     "stylelint": "^6.5.1",
-    "stylelint-config-standard": "^8.0.0",
+    "stylelint-config-standard": "^9.0.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
     "webpack-hot-middleware": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.2.6",
     "sinon": "^2.0.0-pre",
-    "stylelint": "^6.5.1",
+    "stylelint": "^6.6.0",
     "stylelint-config-standard": "^9.0.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",


### PR DESCRIPTION
When I run 'npm run lint', this warning is shown:

Deprecation Warning: 'number-zero-length-no-unit' has been deprecated, and will be removed in '7.0'. Use 'length-zero-no-unit' instead. See: http://stylelint.io/user-guide/rules/length-zero-no-unit/

update package to remove it.