### PR TITLE
Update version of package jsonwebtoken

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "history": "3.0.0",
     "isomorphic-style-loader": "1.0.0",
     "jade": "1.11.0",
-    "jsonwebtoken": "7.0.0",
+    "jsonwebtoken": "7.0.1",
     "markdown-it": "6.0.5",
     "node-fetch": "1.5.3",
     "normalize.css": "4.1.1",

--- a/src/client.js
+++ b/src/client.js
@@ -109,7 +109,7 @@ function run() {
       query: location.query,
       state: location.state,
       context,
-      render: render.bind(undefined, container, location.state),
+      render: render(undefined, container, location.state),
     }).catch(err => console.error(err)); // eslint-disable-line no-console
   }
 


### PR DESCRIPTION
PR #708 is updating the package `jsonwebtoken` but the build fails because of an error by the linter. This PR solves the issue and passes the linter and tests.