### PR TITLE
Remove usage of babel-polyfill since transform-runtime is already used

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "npm": ">=3.3 <4"
   },
   "dependencies": {
-    "babel-polyfill": "6.9.1",
     "babel-runtime": "6.9.2",
     "bluebird": "3.4.0",
     "body-parser": "1.15.1",

--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,6 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import 'babel-polyfill';
 import ReactDOM from 'react-dom';
 import FastClick from 'fastclick';
 import UniversalRouter from 'universal-router';

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,6 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import 'babel-polyfill';
 import path from 'path';
 import express from 'express';
 import cookieParser from 'cookie-parser';


### PR DESCRIPTION
They can work together, but will have unexpected results after babel
upgrade >= 6.9.1 if relying on global regenerator runtime.
(It will not be available globally like it used to be < 6.9.1)
