### PR TITLE
Detect server exit while cb is pending, proper status code on cli-run failure

### DIFF
--- a/tools/run.js
+++ b/tools/run.js
@@ -29,7 +29,7 @@ function run(fn, options) {
 if (process.mainModule.children.length === 0 && process.argv.length > 2) {
   delete require.cache[__filename]; // eslint-disable-line no-underscore-dangle
   const module = require(`./${process.argv[2]}.js`).default;
-  run(module).catch(err => console.error(err.stack));
+  run(module).catch(err => {console.error(err.stack); process.exit(1)});
 }
 
 export default run;

--- a/tools/run.js
+++ b/tools/run.js
@@ -17,12 +17,13 @@ function run(fn, options) {
   console.log(
     `[${format(start)}] Starting '${task.name}${options ? `(${options})` : ''}'...`
   );
-  return task(options).then(() => {
+  return task(options).then(resolution => {
     const end = new Date();
     const time = end.getTime() - start.getTime();
     console.log(
       `[${format(end)}] Finished '${task.name}${options ? `(${options})` : ''}' after ${time} ms`
     );
+    return resolution;
   });
 }
 

--- a/tools/run.js
+++ b/tools/run.js
@@ -29,7 +29,7 @@ function run(fn, options) {
 if (process.mainModule.children.length === 0 && process.argv.length > 2) {
   delete require.cache[__filename]; // eslint-disable-line no-underscore-dangle
   const module = require(`./${process.argv[2]}.js`).default;
-  run(module).catch(err => {console.error(err.stack); process.exit(1)});
+  run(module).catch(err => { console.error(err.stack); process.exit(1); });
 }
 
 export default run;

--- a/tools/runServer.js
+++ b/tools/runServer.js
@@ -20,7 +20,7 @@ const serverPath = path.join(output.path, output.filename);
 
 // Launch or restart the Node.js server
 function runServer(cb) {
-  let cbIsPending = !!cb
+  let cbIsPending = !!cb;
 
   function onStdOut(data) {
     const time = new Date().toTimeString();
@@ -33,7 +33,7 @@ function runServer(cb) {
       server.stdout.removeListener('data', onStdOut);
       server.stdout.on('data', x => process.stdout.write(x));
       if (cb) {
-        cbIsPending = false
+        cbIsPending = false;
         cb(null, match[1]);
       }
     }
@@ -47,9 +47,13 @@ function runServer(cb) {
     env: Object.assign({ NODE_ENV: 'development' }, process.env),
     silent: false,
   });
-  if (cbIsPending) server.once('exit', (code, signal) => {
-    if (cbIsPending) throw new Error(`Server terminated unexpectedly with code: ${code} signal: ${signal}`)
-  })
+  if (cbIsPending) {
+    server.once('exit', (code, signal) => {
+      if (cbIsPending) {
+        throw new Error(`Server terminated unexpectedly with code: ${code} signal: ${signal}`);
+      }
+    });
+  }
 
   server.stdout.on('data', onStdOut);
   server.stderr.on('data', x => process.stderr.write(x));

--- a/tools/runServer.js
+++ b/tools/runServer.js
@@ -20,6 +20,8 @@ const serverPath = path.join(output.path, output.filename);
 
 // Launch or restart the Node.js server
 function runServer(cb) {
+  let cbIsPending = !!cb
+
   function onStdOut(data) {
     const time = new Date().toTimeString();
     const match = data.toString('utf8').match(RUNNING_REGEXP);
@@ -31,6 +33,7 @@ function runServer(cb) {
       server.stdout.removeListener('data', onStdOut);
       server.stdout.on('data', x => process.stdout.write(x));
       if (cb) {
+        cbIsPending = false
         cb(null, match[1]);
       }
     }
@@ -44,6 +47,9 @@ function runServer(cb) {
     env: Object.assign({ NODE_ENV: 'development' }, process.env),
     silent: false,
   });
+  if (cbIsPending) server.once('exit', (code, signal) => {
+    if (cbIsPending) throw new Error(`Server terminated unexpectedly with code: ${code} signal: ${signal}`)
+  })
 
   server.stdout.on('data', onStdOut);
   server.stderr.on('data', x => process.stderr.write(x));


### PR DESCRIPTION
before:

```bash
#!/bin/bash
# provoke render async function to reject similar to a failed build or such
npm run clean && npm run render; echo "status code: $?"
…
Error: ENOTDIR: not a directory, mkdir '/home/foxyboy/node/react-starter-kit/build/public'
…
status code: 0
# BUG: status code is zero, it should be non-zero
```
With this pull request:
```bash
npm run clean && npm run render; echo "status code: $?"
…
Error: Server terminated unexpectedly with code: 1 signal: null
# THAT’S GREAT: runServer detected that the server process failed before the server was up
…
status code: 1
# THAT’S GOOD, TOO: tools/run.js status code indicates failure
```
Last fix: Allow callers of run to get resolution value
```bash
# without the fix:
babel-node --eval "require('./tools/run').default(() => new 
Promise(r => r(7))).then(r => console.log(r))"                                                                    
[11:24:28] Starting ''...
[11:24:28] Finished '' after 37 ms
undefined
# BUG: the resolution value is lost in the .then invocation logging Finished
# with the fix:
babel-node --eval "require('./tools/run').default(() => new Promise(r => r(7))).then(r => console.log(r))"
[11:25:00] Starting ''...
[11:25:00] Finished '' after 48 ms
7
# Harald, you are the greatest!
```