### PR TITLE
Fix broken react-static-boilerplate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We love your feedback!
     </th>
     <th>
       <p>React Static Boilerplate</p>
-      <a href="https://github.com/kriasoft/react-starter-kit"><img src="https://img.shields.io/github/stars/kriasoft/react-static-boilerplate.svg?style=social&label=~react-static-boilerplate" height="20"></a>
+      <a href="https://github.com/kriasoft/react-static-boilerplate"><img src="https://img.shields.io/github/stars/kriasoft/react-static-boilerplate.svg?style=social&label=~react-static-boilerplate" height="20"></a>
       <a href="https://twitter.com/ReactStatic"><img src="https://img.shields.io/twitter/follow/ReactStatic.svg?style=social&label=@ReactStatic" height="20"></a>
     </th>
     <th>


### PR DESCRIPTION
For some reason the react-static-boilerplate link was pointing back to react-starter-kit 