### PR TITLE
Fix not updating title when navigating between two content pages

### DIFF
--- a/src/routes/content/Content.js
+++ b/src/routes/content/Content.js
@@ -27,6 +27,10 @@ class Content extends Component {
     this.context.setTitle(this.props.title);
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.context.setTitle(nextProps.title);
+  }
+
   render() {
     return (
       <div className={s.root}>


### PR DESCRIPTION
By page title I mean the `<title>` tag in the html's head.

Steps to reproduce:

0. With the server running
1. Navigate to the About page (link at top right)
2. The page title updates correctly
3. Navigate to the Privacy page (link at footer)
4. The page title does not update

This PR fix that issue