### PR TITLE
Fix webpack configuration, server side code splitting

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -261,7 +261,9 @@ const serverConfig = extend(true, {}, config, {
   entry: './server.js',
 
   output: {
-    filename: '../../server.js',
+    path: path.resolve(__dirname, '../build'),
+    filename: 'server.js',
+    chunkFilename: 'server.[name].js',
     libraryTarget: 'commonjs2',
   },
 


### PR DESCRIPTION
This fixes invalid behavior of `require.ensure` in server code