### PR TITLE
Checks if bootstrap fonts folder exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-react": "^5.1.1",
     "extend": "^3.0.0",
     "file-loader": "^0.8.5",
+    "fs": "0.0.2",
     "gaze": "^1.0.0",
     "git-repository": "^0.1.4",
     "glob": "^7.0.3",

--- a/tools/copy.js
+++ b/tools/copy.js
@@ -12,6 +12,7 @@ import gaze from 'gaze';
 import Promise from 'bluebird';
 import fs from './lib/fs';
 import pkg from '../package.json';
+import _fs from 'fs';
 /**
  * Copies static files such as robots.txt, favicon.ico to the
  * output (build) folder.
@@ -19,12 +20,18 @@ import pkg from '../package.json';
 async function copy({ watch } = {}) {
   const ncp = Promise.promisify(require('ncp'));
 
-  await Promise.all([
-    ncp('node_modules/bootstrap/dist/css', 'build/public/css'),
-    ncp('node_modules/bootstrap/dist/fonts', 'build/public/fonts'),
+  var ncpArray = [
     ncp('src/public', 'build/public'),
     ncp('src/content', 'build/content'),
-  ]);
+    ncp('node_modules/bootstrap/dist/css', 'build/public/css')
+  ];
+  try {
+    _fs.statSync('node_modules/bootstrap/dist/fonts');
+    ncpArray.push(ncp('node_modules/bootstrap/dist/fonts', 'build/public/fonts'));
+  } catch(err) {
+    console.warn('node_modules/bootstrap/dist/fonts not found');
+  }
+  await Promise.all(ncpArray);
 
   await fs.writeFile('./build/package.json', JSON.stringify({
     private: true,


### PR DESCRIPTION
Some versions of bootstrap do not come with a fonts directory. This fix allows such versions of bootstrap to be used with this branch.
