### PR TITLE
Update postcss-selector-matches up to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "postcss-media-minmax": "^2.1.2",
     "postcss-nesting": "^2.3.1",
     "postcss-pseudoelements": "^3.0.0",
-    "postcss-selector-matches": "^2.0.1",
+    "postcss-selector-matches": "^2.0.3",
     "postcss-selector-not": "^2.0.0",
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "15.3.1",


### PR DESCRIPTION
> ### [2.0.3 - 2016-09-06](https://github.com/postcss/postcss-selector-matches/blob/master/CHANGELOG.md)
> Fixed: regression of 2.0.2 due to a transpilation upgrade (@MoOx)

Fixes #834