### PR TITLE
It should be emailConfirmed instead of emailVerified.

### DIFF
--- a/src/core/passport.js
+++ b/src/core/passport.js
@@ -92,7 +92,7 @@ passport.use(new FacebookStrategy({
         } else {
           user = await User.create({
             email: profile._json.email,
-            emailVerified: true,
+            emailConfirmed: true,
             logins: [
               { name: loginName, key: profile.id },
             ],


### PR DESCRIPTION
When double checking the database to see if emailConfirmed had been marked as true after login it was apparent that 'emailVerified' is not a valid field of the module User.