### PR TITLE
Allow load critical but optional polyfills

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -156,16 +156,20 @@ async function onLocationChange(location) {
   }
 }
 
-// Handle client-side navigation by using HTML5 History API
-// For more information visit https://github.com/mjackson/history#readme
-context.history.listen(onLocationChange);
-onLocationChange(currentLocation);
+export default function main() {
+  // Handle client-side navigation by using HTML5 History API
+  // For more information visit https://github.com/mjackson/history#readme
+  currentLocation = context.history.location;
+  context.history.listen(onLocationChange);
+  onLocationChange(currentLocation);
+}
 
 // Enable Hot Module Replacement (HMR)
 if (module.hot) {
   module.hot.accept('./routes', () => {
     routes = require('./routes').default; // eslint-disable-line global-require
 
+    currentLocation = context.history.location;
     onLocationChange(currentLocation);
   });
 }

--- a/src/clientLoader.js
+++ b/src/clientLoader.js
@@ -1,0 +1,31 @@
+
+// polyfills
+import 'babel-polyfill';
+import main from './client';
+
+function run() {
+  // Run the application when both DOM is ready and page content is loaded
+  if (['complete', 'loaded', 'interactive'].includes(document.readyState) && document.body) {
+    main();
+  } else {
+    document.addEventListener('DOMContentLoaded', main, false);
+  }
+}
+
+const needHeavyPolyfills = false;
+
+if (needHeavyPolyfills) {
+  // You can show loading banner here
+
+  require.ensure([
+    // Add all large polyfills here
+  ], (require) => { // eslint-disable-line no-unused-vars
+    // and require them here
+    // require('intl');
+    // require('intl/locale-data/jsonp/en.js');
+
+    run();
+  }, 'polyfills');
+} else {
+  run();
+}

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -201,7 +201,7 @@ const config = {
 // -----------------------------------------------------------------------------
 
 const clientConfig = extend(true, {}, config, {
-  entry: './client.js',
+  entry: './clientLoader.js',
 
   output: {
     filename: DEBUG ? '[name].js?[chunkhash]' : '[name].[chunkhash].js',


### PR DESCRIPTION
This patch allows load heavy polyfills (such as intl) asynchronously and optionally before app run through webpack code splitting feature.
