### PR TITLE
Fix/mac osx cpu

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-react": "^6.3.0",
     "extend": "^3.0.0",
     "file-loader": "^0.9.0",
+    "fsevents": "^1.0.14",
     "gaze": "^1.1.1",
     "git-repository": "^0.1.4",
     "glob": "^7.1.0",

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -43,6 +43,11 @@ const config = {
     sourcePrefix: '  ',
   },
 
+  watchOptions: {
+    poll: false,
+    ignored: /node_modules/,
+  },
+
   module: {
     loaders: [
       {


### PR DESCRIPTION
I had problems with clean RSK eating 60% CPU and my project eating 100% (and more). 

Seems webpacks watchpack enters polling mode on Mac OSX without fsevents so I added it as suggested here https://github.com/webpack/webpack-dev-middleware/issues/40

It helped and dropped my CPU usage to stable ~10% on my project and <5% on RSK.

Also webpack seems to watch files in node_modules (which has been fixed) so I added `watchOptions` to webpack.config.js as suggested here https://github.com/JeffreyWay/laravel-elixir-webpack-official/issues/22

I added it but webpack is not my strong side so I don't know if it's in the right place or even needed. Please review so this doesn't cause other problems. 

I tried it in RSK and it works for me.
