### PR TITLE
Fixed test for required store props in App Layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.3.1",
+    "redux-mock-store": "^1.2.1",
     "sinon": "^2.0.0-pre.2",
     "stylelint": "^7.3.1",
     "stylelint-config-standard": "^13.0.2",

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -15,12 +15,16 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import App from '../App';
 import Layout from './Layout';
+import configureStore from 'redux-mock-store';
 
 describe('Layout', () => {
 
   it('renders children correctly', () => {
+    const mockStore = configureStore();
+    const store = mockStore()
+
     const wrapper = shallow(
-      <App context={{ insertCss: () => {} }}>
+      <App context={{ insertCss: () => {}, store }}>
         <Layout>
           <div className="child" />
         </Layout>

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -13,15 +13,15 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import configureStore from 'redux-mock-store';
 import App from '../App';
 import Layout from './Layout';
-import configureStore from 'redux-mock-store';
 
 describe('Layout', () => {
 
   it('renders children correctly', () => {
     const mockStore = configureStore();
-    const store = mockStore()
+    const store = mockStore();
 
     const wrapper = shallow(
       <App context={{ insertCss: () => {}, store }}>


### PR DESCRIPTION
The Layout component failed the test because the inner App component required a `store` in its `PropTypes`.

Issue has been resolved by utilizing [redux-mock-store](https://github.com/arnaudbenard/redux-mock-store) to create a mock store which is then passed into the App component within the Layout test.