### PR TITLE
feature/react-intl add messages folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ database.sqlite
 node_modules
 ncp-debug.log
 npm-debug.log
+src/messages


### PR DESCRIPTION
Since we extract the messages folder with each new build or by running start, shouldn't we remove these from tracking?