### PR TITLE
Improve Hot Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "postcss-url": "^5.1.2",
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "15.3.2",
+    "react-deep-force-update": "^2.0.1",
     "react-hot-loader": "^3.0.0-beta.6",
     "redbox-react": "^1.3.2",
     "rimraf": "^2.5.4",

--- a/src/core/devUtils.js
+++ b/src/core/devUtils.js
@@ -1,0 +1,22 @@
+/**
+ * React Starter Kit (https://www.reactstarterkit.com/)
+ *
+ * Copyright © 2014-2016 Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+if (module.hot || process.env.NODE_ENV !== 'production') {
+  module.exports = {
+    // The red box (aka red screen of death) component to display your errors
+    // https://github.com/commissure/redbox-react
+    ErrorReporter: require('redbox-react').default,
+
+    // Force-updates React component tree recursively
+    // https://github.com/gaearon/react-deep-force-update
+    deepForceUpdate: require('react-deep-force-update'),
+  };
+}

--- a/src/core/history.js
+++ b/src/core/history.js
@@ -1,3 +1,12 @@
+/**
+ * React Starter Kit (https://www.reactstarterkit.com/)
+ *
+ * Copyright © 2014-2016 Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
 import createBrowserHistory from 'history/createBrowserHistory';
 
 // Navigation manager, e.g. history.push('/home')


### PR DESCRIPTION
- Add support for hot update of [`PureComponent`](https://facebook.github.io/react/docs/react-api.html#react.purecomponent) and components with [`shouldComponentUpdate`](https://facebook.github.io/react/docs/react-component.html#shouldcomponentupdate)
- Display application errors at full-screen in development mode
- Display hot update errors at full-screen when hot module replacement is enabled

closes #932, #929, #907, #871, #772, #436 

_This PR is waiting for your feedback_ ⏳  
