### PR TITLE
Fixes #970: Remove the graphiql module since express-graphql loads this via cdn, …

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "fastclick": "1.0.6",
     "fbjs": "0.8.5",
     "front-matter": "2.1.0",
-    "graphiql": "0.7.8",
     "graphql": "0.7.2",
     "history": "4.4.0",
     "isomorphic-style-loader": "1.1.0",

--- a/src/server.js
+++ b/src/server.js
@@ -75,7 +75,7 @@ app.get('/login/facebook/return',
 // -----------------------------------------------------------------------------
 app.use('/graphql', expressGraphQL(req => ({
   schema,
-  graphiql: true,
+  graphiql: process.env.NODE_ENV !== 'production',
   rootValue: { request: req },
   pretty: process.env.NODE_ENV !== 'production',
 })));


### PR DESCRIPTION
Remove the graphiql module since express-graphql loads this via cdn, disable graphiql ide in for production servers. See #970 for discussion.