### PR TITLE
Use correct absolute callbackURL in passport with Browsersync

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -57,6 +57,9 @@ app.use(expressJwt({
 }));
 app.use(passport.initialize());
 
+if (process.env.NODE_ENV !== 'production') {
+  app.enable('trust proxy');
+}
 app.get('/login/facebook',
   passport.authenticate('facebook', { scope: ['email', 'user_location'], session: false }),
 );

--- a/tools/start.js
+++ b/tools/start.js
@@ -66,6 +66,9 @@ async function start() {
         proxy: {
           target: server.host,
           middleware: [wpMiddleware, hotMiddleware],
+          proxyOptions: {
+            xfwd: true,
+          },
         },
       }, resolve);
     };


### PR DESCRIPTION
When using browsersync at `localhost:9001` and trying to log in with Facebook account, I am redirected to `localhost:9000`. To avoid this and continue with `localhost:9001` I configured Browsersync proxy to set X-Forwarded headers and set passport to trust them (when not running in production mode). This way I am redirected back to `localhost:9001` from Facebook.

This is my first pull request, so please let me know if you see something I should improve. Thanks :)