### PR TITLE
Removed spacing on `git clone` command.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,7 +56,7 @@ local machine by running:
 
 ```shell
 $ git clone -o react-starter-kit -b master --single-branch \
-      https://github.com/kriasoft/react-starter-kit.git MyApp
+https://github.com/kriasoft/react-starter-kit.git MyApp
 $ cd MyApp
 ```
 


### PR DESCRIPTION
So that copy-pasting in terminal won't include spaces which will throw errors.