### PR TITLE
Move vendors to separate bundle

### DIFF
--- a/src/components/Html.js
+++ b/src/components/Html.js
@@ -15,13 +15,12 @@ class Html extends React.Component {
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     style: PropTypes.string,
-    script: PropTypes.string,
-    chunk: PropTypes.string,
+    scripts: PropTypes.arrayOf(PropTypes.string.isRequired),
     children: PropTypes.string,
   };
 
   render() {
-    const { title, description, style, script, chunk, children } = this.props;
+    const { title, description, style, scripts, children } = this.props;
     return (
       <html className="no-js" lang="en">
         <head>
@@ -35,8 +34,7 @@ class Html extends React.Component {
         </head>
         <body>
           <div id="app" dangerouslySetInnerHTML={{ __html: children }} />
-          {script && <script src={script} />}
-          {chunk && <script src={chunk} />}
+          {scripts && scripts.map(script => <script key={script} src={script} />)}
           {analytics.google.trackingId &&
             <script
               dangerouslySetInnerHTML={{ __html:

--- a/src/server.js
+++ b/src/server.js
@@ -111,10 +111,15 @@ app.get('*', async (req, res, next) => {
     const data = { ...route };
     data.children = ReactDOM.renderToString(<App context={context}>{route.component}</App>);
     data.style = [...css].join('');
-    data.script = assets.client.js;
-    data.chunk = assets[route.chunk] && assets[route.chunk].js;
-    const html = ReactDOM.renderToStaticMarkup(<Html {...data} />);
+    data.scripts = [
+      assets.vendor.js,
+      assets.client.js,
+    ];
+    if (assets[route.chunk]) {
+      data.scripts.push(assets[route.chunk].js);
+    }
 
+    const html = ReactDOM.renderToStaticMarkup(<Html {...data} />);
     res.status(route.status || 200);
     res.send(`<!doctype html>${html}`);
   } catch (err) {

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -27,6 +27,7 @@ const config = {
     path: path.resolve(__dirname, '../build/public/assets'),
     publicPath: '/assets/',
     sourcePrefix: '  ',
+    pathinfo: isVerbose,
   },
 
   module: {
@@ -247,6 +248,13 @@ const clientConfig = extend(true, {}, config, {
     // Consistent ordering of modules required if using any hashing ([hash] or [chunkhash])
     // https://webpack.github.io/docs/list-of-plugins.html#occurrenceorderplugin
     new webpack.optimize.OccurrenceOrderPlugin(true),
+
+    // Move modules that occur in multiple entry chunks to a new entry chunk (the commons chunk).
+    // http://webpack.github.io/docs/list-of-plugins.html#commonschunkplugin
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: module => /node_modules/.test(module.resource),
+    }),
 
     ...isDebug ? [] : [
       // Search for equal or similar files and deduplicate them in the output


### PR DESCRIPTION
Pros
- Visitors will need to download less data after regular deployment (probably you will the change application code more often than vendor libraries)
- You will be able to see the real size of your application bundle
- Hope it can help to improve hot update speed in huge code bases

Cons
- One more http request only at first page load

..or maybe we should split vendors to separate chunk only in development mode, what do you think?