### PR TITLE
Fixes #987: Expose state and search props of the history module on the Link compo…

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -39,11 +39,25 @@ class Link extends React.Component {
     }
 
     event.preventDefault();
-    history.push(this.props.to);
+    history.push({
+      pathname: this.props.to,
+      state: this.props.state ? this.props.state : undefined,
+      search: this.props.query ? this.params(this.props.query) : undefined
+    });
   };
 
+  params = (arg) => {
+    if (typeof arg === 'string') {
+      return arg.startsWith('?') ? arg : `?${arg}`;
+    } else if (arg === Object(arg) && Object.prototype.toString.call(arg) === '[object Object]' ) {
+      return '?' + Object.keys(this.props.query).map((key) => (
+        `${encodeURIComponent(key)}=${encodeURIComponent(this.props.query[key])}`
+      )).join('&');
+    }
+  }
+
   render() {
-    const { to, children, ...props } = this.props;
+    const { to, children, query, state, ...props } = this.props;
     return <a href={to} {...props} onClick={this.handleClick}>{children}</a>;
   }
 }

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -21,6 +21,11 @@ function isModifiedEvent(event) {
 class Link extends React.Component {
   static propTypes = {
     to: PropTypes.string.isRequired,
+    query: PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.object,
+    ]),
+    state: PropTypes.object,
     children: PropTypes.node,
     onClick: PropTypes.func,
   };
@@ -42,21 +47,26 @@ class Link extends React.Component {
     history.push({
       pathname: this.props.to,
       state: this.props.state ? this.props.state : undefined,
-      search: this.props.query ? this.params(this.props.query) : undefined
+      search: this.props.query ? this.params(this.props.query) : undefined,
     });
   };
 
   params = (arg) => {
+    let params;
+
     if (typeof arg === 'string') {
-      return arg.startsWith('?') ? arg : `?${arg}`;
-    } else if (arg === Object(arg) && Object.prototype.toString.call(arg) === '[object Object]' ) {
-      return '?' + Object.keys(this.props.query).map((key) => (
+      params = arg.startsWith('?') ? arg : `?${arg}`;
+    } else if (arg === Object(arg) && Object.prototype.toString.call(arg) === '[object Object]') {
+      params = `?${Object.keys(this.props.query).map((key) => (
         `${encodeURIComponent(key)}=${encodeURIComponent(this.props.query[key])}`
-      )).join('&');
+      )).join('&')}`;
     }
+
+    return params;
   }
 
   render() {
+    // eslint-disable-next-line no-unused-vars
     const { to, children, query, state, ...props } = this.props;
     return <a href={to} {...props} onClick={this.handleClick}>{children}</a>;
   }


### PR DESCRIPTION
See #987 for extended discussion. Expose state and search (aka query) properties of `history` module in the Link component. Automatically parameterize shallow objects and optionally allow a string to be used as the query prop.