### PR TITLE
Update how-to-use-sass.md

### DIFF
--- a/docs/recipes/how-to-use-sass.md
+++ b/docs/recipes/how-to-use-sass.md
@@ -30,7 +30,7 @@ const config = {
         test: /\.scss$/,
         loaders: [
           'isomorphic-style-loader',
-          `css-loader?${JSON.stringify({ sourceMap: DEBUG, minimize: !DEBUG })}`,
+          `css-loader?${JSON.stringify({ sourceMap: isDebug, minimize: !isDebug })}`,
           'postcss-loader?pack=sass',
           'sass-loader',
         ],


### PR DESCRIPTION
The current name for the debug variable is `isDebug`, not `DEBUG`.