### PR TITLE
Fix bug with joining dir and path in render

### DIFF
--- a/tools/render.js
+++ b/tools/render.js
@@ -45,7 +45,7 @@ async function render() {
     const url = `http://${server.host}${route}`;
     const fileName = route.endsWith('/') ? 'index.html' : `${path.basename(route, '.html')}.html`;
     const dirName = path.join('build/public', route.endsWith('/') ? route : path.dirname(route));
-    const dist = `${dirName}${fileName}`;
+    const dist = path.join(dirName, fileName);
     const timeStart = new Date();
     const response = await fetch(url);
     const timeEnd = new Date();


### PR DESCRIPTION
I'm guessing this is a platform specific bug. It appeared on Mac OSX 10.11.5.