### PR TITLE
Fixes #1081: UglifyJS2 should remove unused and dead_code

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -270,6 +270,8 @@ const clientConfig = extend(true, {}, config, {
         compress: {
           screw_ie8: true, // React doesn't support IE8
           warnings: isVerbose,
+          unused: true,
+          dead_code: true,
         },
         mangle: {
           screw_ie8: true,


### PR DESCRIPTION
Resolve #1081 
We currently do not leverage UglifyJS2 unused and dead_code options during the compress stage when generating production builds.

Current state:
```
// tools/webpack.config.js
...
      new webpack.optimize.UglifyJsPlugin({
        compress: {
          screw_ie8: true, // React doesn't support IE8
          warnings: isVerbose,
        },
        mangle: {
          screw_ie8: true,
        },
        output: {
          comments: false,
          screw_ie8: true,
        },
      }),
...
```

Which outputs the following file sizes when running `npm start -- --release`:

```
Child
    Time: 11900ms
                        Asset     Size  Chunks             Chunk Names
                 2f751285.png  2.83 kB          [emitted]  
                 8844262b.png  6.81 kB          [emitted]  
           vendor.89d9f281.js   294 kB       0  [emitted]  vendor
      admin.dcf93f90.chunk.js  1.59 kB       1  [emitted]  admin
    privacy.a218a92e.chunk.js   2.9 kB       2  [emitted]  privacy
      about.689e57ee.chunk.js  2.91 kB       3  [emitted]  about
           client.ba9bcfce.js  39.6 kB       4  [emitted]  client
Child
    Time: 6159ms
                  Asset     Size  Chunks             Chunk Names
           2f751285.png  2.83 kB          [emitted]  
           8844262b.png  6.81 kB          [emitted]  
        ../../server.js   144 kB       0  [emitted]  server
    ../../server.js.map   153 kB       0  [emitted]  server
```

Proposed change is adding unused and dead_code options to compress like so:
```
// tools/webpack.config.js
...
      new webpack.optimize.UglifyJsPlugin({
        compress: {
          screw_ie8: true, // React doesn't support IE8
          warnings: isVerbose,
          unused: true,
          dead_code: true,
        },
        mangle: {
          screw_ie8: true,
        },
        output: {
          comments: false,
          screw_ie8: true,
        },
      }),
...
```

With unused and dead_code turned on the file sizes are (`npm start -- --release`):

```
Child
    Time: 15257ms
                        Asset       Size  Chunks             Chunk Names
                 2f751285.png    2.83 kB          [emitted]  
                 8844262b.png    6.81 kB          [emitted]  
           vendor.89d9f281.js     272 kB       0  [emitted]  vendor
      admin.dcf93f90.chunk.js  918 bytes       1  [emitted]  admin
    privacy.a218a92e.chunk.js     2.9 kB       2  [emitted]  privacy
      about.689e57ee.chunk.js    2.91 kB       3  [emitted]  about
           client.ba9bcfce.js    31.8 kB       4  [emitted]  client
Child
    Time: 15205ms
                  Asset     Size  Chunks             Chunk Names
           2f751285.png  2.83 kB          [emitted]  
           8844262b.png  6.81 kB          [emitted]  
        ../../server.js   144 kB       0  [emitted]  server
    ../../server.js.map   153 kB       0  [emitted]  server

```

Side by side comparison before/after using unused and dead_code:
```
                         Before         After
             2f751285.png  2.83 kB  -->  2.83 kB
             8844262b.png  6.81 kB  -->  6.81 kB
       vendor.89d9f281.js  294 kB  -->  272 kB
  admin.dcf93f90.chunk.js  1.59 kB  -->  918 bytes
privacy.a218a92e.chunk.js  2.9 kB  -->  2.9 kB
  about.689e57ee.chunk.js  2.91 kB  -->  2.91 kB
       client.ba9bcfce.js  39.6 kB  -->  31.8 kB
```

What this does is remove code like variable declarations that are never used (unused) and code that is never reached (dead_code) in a production build like `if (__DEV__) console.log('Some dev only warning')`.