### PR TITLE
Resolve #1085: Free __DEV__ variable provided by webpack should be used instead of NODE_ENV checks

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -159,7 +159,7 @@ async function onLocationChange(location) {
     }
 
     // Display the error in full-screen for development mode
-    if (process.env.NODE_ENV !== 'production') {
+    if (__DEV__) {
       appInstance = null;
       document.title = `Error: ${error.message}`;
       ReactDOM.render(<ErrorReporter error={error} />, container);

--- a/src/core/devUtils.js
+++ b/src/core/devUtils.js
@@ -9,7 +9,7 @@
 
 /* eslint-disable global-require */
 
-if (module.hot || process.env.NODE_ENV !== 'production') {
+if (module.hot || __DEV__) {
   module.exports = {
     // The red box (aka red screen of death) component to display your errors
     // https://github.com/commissure/redbox-react

--- a/src/routes/error/ErrorPage.js
+++ b/src/routes/error/ErrorPage.js
@@ -17,7 +17,7 @@ class ErrorPage extends React.Component {
   };
 
   render() {
-    if (process.env.NODE_ENV !== 'production') {
+    if (__DEV__) {
       const { error } = this.props;
       return (
         <div>

--- a/src/server.js
+++ b/src/server.js
@@ -57,7 +57,7 @@ app.use(expressJwt({
 }));
 app.use(passport.initialize());
 
-if (process.env.NODE_ENV !== 'production') {
+if (__DEV__) {
   app.enable('trust proxy');
 }
 app.get('/login/facebook',
@@ -78,9 +78,9 @@ app.get('/login/facebook/return',
 // -----------------------------------------------------------------------------
 app.use('/graphql', expressGraphQL(req => ({
   schema,
-  graphiql: process.env.NODE_ENV !== 'production',
+  graphiql: __DEV__,
   rootValue: { request: req },
-  pretty: process.env.NODE_ENV !== 'production',
+  pretty: __DEV__,
 })));
 
 //

--- a/tools/.eslintrc
+++ b/tools/.eslintrc
@@ -1,6 +1,14 @@
 {
   "rules": {
     "no-console": 0,
-    "global-require": 0
+    "global-require": 0,
+    "no-underscore-dangle": [
+      1,
+      {
+        "allow": [
+          "__DEV__"
+        ]
+      }
+    ]
   }
 }

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -270,6 +270,8 @@ const clientConfig = extend(true, {}, config, {
         compress: {
           screw_ie8: true, // React doesn't support IE8
           warnings: isVerbose,
+          unused: true,
+          dead_code: true,
         },
         mangle: {
           screw_ie8: true,

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -12,7 +12,7 @@ import webpack from 'webpack';
 import extend from 'extend';
 import AssetsPlugin from 'assets-webpack-plugin';
 
-const isDebug = !process.argv.includes('--release');
+const __DEV__ = !process.argv.includes('--release');
 const isVerbose = process.argv.includes('--verbose');
 
 //
@@ -40,7 +40,7 @@ const config = {
         ],
         query: {
           // https://github.com/babel/babel-loader#options
-          cacheDirectory: isDebug,
+          cacheDirectory: __DEV__,
 
           // https://babeljs.io/docs/usage/options/
           babelrc: false,
@@ -54,7 +54,7 @@ const config = {
             // JSX, Flow
             // https://github.com/babel/babel/tree/master/packages/babel-preset-react
             'react',
-            ...isDebug ? [] : [
+            ...__DEV__ ? [] : [
               // Optimize React code for the production build
               // https://github.com/thejameskyle/babel-react-optimize
               'react-optimize',
@@ -65,7 +65,7 @@ const config = {
             // automatically polyfilling your code without polluting globals.
             // https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime
             'transform-runtime',
-            ...!isDebug ? [] : [
+            ...!__DEV__ ? [] : [
               // Adds component stack to warning messages
               // https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source
               'transform-react-jsx-source',
@@ -83,12 +83,12 @@ const config = {
           `css-loader?${JSON.stringify({
             // CSS Loader https://github.com/webpack/css-loader
             importLoaders: 1,
-            sourceMap: isDebug,
+            sourceMap: __DEV__,
             // CSS Modules https://github.com/css-modules/css-modules
             modules: true,
-            localIdentName: isDebug ? '[name]-[local]-[hash:base64:5]' : '[hash:base64:5]',
+            localIdentName: __DEV__ ? '[name]-[local]-[hash:base64:5]' : '[hash:base64:5]',
             // CSS Nano http://cssnano.co/options/
-            minimize: !isDebug,
+            minimize: !__DEV__,
             discardComments: { removeAll: true },
           })}`,
           'postcss-loader?pack=default',
@@ -110,14 +110,14 @@ const config = {
         test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
         loader: 'file-loader',
         query: {
-          name: isDebug ? '[path][name].[ext]?[hash:8]' : '[hash:8].[ext]',
+          name: __DEV__ ? '[path][name].[ext]?[hash:8]' : '[hash:8].[ext]',
         },
       },
       {
         test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
         loader: 'url-loader',
         query: {
-          name: isDebug ? '[path][name].[ext]?[hash:8]' : '[hash:8].[ext]',
+          name: __DEV__ ? '[path][name].[ext]?[hash:8]' : '[hash:8].[ext]',
           limit: 10000,
         },
       },
@@ -131,14 +131,14 @@ const config = {
   },
 
   // Don't attempt to continue if there are any errors.
-  bail: !isDebug,
+  bail: !__DEV__,
 
-  cache: isDebug,
-  debug: isDebug,
+  cache: __DEV__,
+  debug: __DEV__,
 
   stats: {
     colors: true,
-    reasons: isDebug,
+    reasons: __DEV__,
     hash: isVerbose,
     version: isVerbose,
     timings: true,
@@ -223,8 +223,8 @@ const clientConfig = extend(true, {}, config, {
   },
 
   output: {
-    filename: isDebug ? '[name].js' : '[name].[chunkhash:8].js',
-    chunkFilename: isDebug ? '[name].chunk.js' : '[name].[chunkhash:8].chunk.js',
+    filename: __DEV__ ? '[name].js' : '[name].[chunkhash:8].js',
+    chunkFilename: __DEV__ ? '[name].chunk.js' : '[name].[chunkhash:8].chunk.js',
   },
 
   target: 'web',
@@ -234,9 +234,9 @@ const clientConfig = extend(true, {}, config, {
     // Define free variables
     // https://webpack.github.io/docs/list-of-plugins.html#defineplugin
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': isDebug ? '"development"' : '"production"',
+      'process.env.NODE_ENV': __DEV__ ? '"development"' : '"production"',
       'process.env.BROWSER': true,
-      __DEV__: isDebug,
+      __DEV__,
     }),
 
     // Emit a file with assets paths
@@ -254,7 +254,7 @@ const clientConfig = extend(true, {}, config, {
       minChunks: module => /node_modules/.test(module.resource),
     }),
 
-    ...isDebug ? [] : [
+    ...__DEV__ ? [] : [
       // Assign the module and chunk ids by occurrence count
       // Consistent ordering of modules required if using any hashing ([hash] or [chunkhash])
       // https://webpack.github.io/docs/list-of-plugins.html#occurrenceorderplugin
@@ -286,7 +286,7 @@ const clientConfig = extend(true, {}, config, {
 
   // Choose a developer tool to enhance debugging
   // http://webpack.github.io/docs/configuration.html#devtool
-  devtool: isDebug ? 'cheap-module-source-map' : false,
+  devtool: __DEV__ ? 'cheap-module-source-map' : false,
 
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.
@@ -329,9 +329,9 @@ const serverConfig = extend(true, {}, config, {
     // Define free variables
     // https://webpack.github.io/docs/list-of-plugins.html#defineplugin
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': isDebug ? '"development"' : '"production"',
+      'process.env.NODE_ENV': __DEV__ ? '"development"' : '"production"',
       'process.env.BROWSER': false,
-      __DEV__: isDebug,
+      __DEV__,
     }),
 
     // Do not create separate chunks of the server bundle
@@ -353,7 +353,7 @@ const serverConfig = extend(true, {}, config, {
     __dirname: false,
   },
 
-  devtool: isDebug ? 'cheap-module-source-map' : 'source-map',
+  devtool: __DEV__ ? 'cheap-module-source-map' : 'source-map',
 });
 
 export default [clientConfig, serverConfig];


### PR DESCRIPTION
Resolve #1085 
To my knowledge, `__DEV__` is a facebook code idiom that showed up relatively recently in the main React repo. Can see it all over the place [here](https://github.com/facebook/react/search?utf8=%E2%9C%93&q=__DEV__) (may need to login to see github search results). Their build process has a step that replaces `__DEV__` with `process.env.NODE_ENV !== 'production'`. 

RSK currently has something similar, `__DEV__` is made available via webpack, we just have not been using it. This is likely due to a missing exception in the `.eslintrc` allowing a `no-underscore-dangle` exception for `__DEV__` (and lack awareness of availability too!).

Can see where `__DEV__` is made available in the current [webpack.config.js](https://github.com/kriasoft/react-starter-kit/blob/master/tools/webpack.config.js#L239) here (same for client/server):
```
// tools/webpack.config.js
... 
   // Define free variables
    // https://webpack.github.io/docs/list-of-plugins.html#defineplugin
    new webpack.DefinePlugin({
      'process.env.NODE_ENV': isDebug ? '"development"' : '"production"',
      'process.env.BROWSER': true,
      __DEV__: isDebug,
    }),
...
```

Pull request would replace both process.env.NODE_ENV !== 'production' statements with `__DEV__` and add a `no-comma-dangle` exception to the `.eslintrc`. `isDebug` in `webpack.config.js` should also be converted into `__DEV__` as there is no reason to violate convention.

++Readability