### PR TITLE
Adds error handler for errors that might happen after rendering.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -176,6 +176,18 @@ async function onLocationChange(location) {
 history.listen(onLocationChange);
 onLocationChange(currentLocation);
 
+// Handle errors that might happen after rendering
+// Display the error in full-screen for development mode
+// Fallback to console.error in production mode
+window.addEventListener('error', (e) => {
+  console.error(e.error); // eslint-disable-line no-console
+
+  if (process.env.NODE_ENV !== 'production') {
+    document.title = `Error: ${e.error.message}`;
+    ReactDOM.render(<ErrorReporter error={e.error} />, container);
+  }
+});
+
 // Enable Hot Module Replacement (HMR)
 if (module.hot) {
   module.hot.accept('./routes', () => {

--- a/src/client.js
+++ b/src/client.js
@@ -178,15 +178,14 @@ onLocationChange(currentLocation);
 
 // Handle errors that might happen after rendering
 // Display the error in full-screen for development mode
-// Fallback to console.error in production mode
-window.addEventListener('error', (e) => {
-  console.error(e.error); // eslint-disable-line no-console
+if (process.env.NODE_ENV !== 'production') {
+  window.addEventListener('error', (e) => {
+    console.error(e.error); // eslint-disable-line no-console
 
-  if (process.env.NODE_ENV !== 'production') {
     document.title = `Error: ${e.error.message}`;
     ReactDOM.render(<ErrorReporter error={e.error} />, container);
-  }
-});
+  });
+}
 
 // Enable Hot Module Replacement (HMR)
 if (module.hot) {


### PR DESCRIPTION
Currently when there's an error in e.g. `onClick` handler, error is being shown only in browser console.

It might flew unnoticed by developer.

After this change it should show up in full screen for development mode.

@nupurkapoor, @GalGavu, @noahehall and me are using it for our project and it works just fine so we've decided it might be worth to introduce it to Your codebase.