### PR TITLE
Remove unused fbjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "express-graphql": "^0.6.3",
     "express-jwt": "^5.1.0",
     "fastclick": "^1.0.6",
-    "fbjs": "^0.8.9",
     "graphql": "^0.9.1",
     "history": "^4.5.1",
     "isomorphic-style-loader": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,11 +46,11 @@ acorn@^3.0.4, acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.11:
+acorn@^4.0.11, acorn@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-acorn@^4.0.3, acorn@^4.0.4:
+acorn@^4.0.4:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.10.tgz#598ed8bdd4de8b5a7a7fa2f6d2188ebbf9b1f12c"
 
@@ -2686,7 +2686,7 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:


### PR DESCRIPTION
Fix #1152 -- Quick repo search reveals that we do not actually use the `fbjs` dependency anywhere in code (mentioned in docs once). This is a good thing granted fbjs is for internal use and not publicly supported by FB.