### PR TITLE
Sets NODE_ENV environment var to `production` in docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ WORKDIR /usr/src/app
 RUN npm install yarn --global --no-progress --silent --depth 0 && \
     yarn install --production --no-progress
 
+# Set NODE_ENV env variable to "production" for faster expressjs
+ENV NODE_ENV production
+
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
Setting `NODE_ENV` variable to `production` is recommended before starting expressjs.

Below are my benchmark results for docker images build with and without `NODE_ENV` defined.

Without `NODE_ENV`:
```sh
wrk -t12 -c500 -d30s http://localhost:3000/
Running 30s test @ http://localhost:3000/
  12 threads and 500 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.60s   330.54ms   2.00s    81.58%
    Req/Sec     9.63      9.36    98.00     79.66%
  2227 requests in 30.09s, 389.28MB read
  Socket errors: connect 0, read 16210, write 0, timeout 908
Requests/sec:     74.00
Transfer/sec:     12.94MB
```

With `NODE_ENV`:
```sh
wrk -t12 -c500 -d30s http://localhost:3000/
Running 30s test @ http://localhost:3000/
  12 threads and 500 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.32s   333.08ms   2.00s    58.25%
    Req/Sec    13.69     12.56    98.00     74.46%
  2828 requests in 30.10s, 494.08MB read
  Socket errors: connect 0, read 16945, write 0, timeout 2543
Requests/sec:     93.96
Transfer/sec:     16.42MB
```

Notice Request/sec increase.

This is very vaguely mentioned in expressjs docs. When not setting `NODE_ENV` it fallbacks to `development`.

https://github.com/expressjs/express/blob/b4550fbe7a154d3fb9e935935e266a9eca9a4d69/lib/application.js#L71

If someone would based theirs `Dockerfile` on this repo's `Dockerfile`, they might also forgot about setting `NODE_ENV` resulting in slower expressjs app.

More on this topic - https://expressjs.com/en/advanced/best-practice-performance.html