### PR TITLE
Fix jwt error signing recursive json when logging in from second browser

### DIFF
--- a/src/core/passport.js
+++ b/src/core/passport.js
@@ -82,7 +82,8 @@ passport.use(new FacebookStrategy({
         ],
       });
       if (users.length) {
-        done(null, users[0]);
+        const user = users[0].get({ plain: true });
+        done(null, user);
       } else {
         let user = await User.findOne({ where: { email: profile._json.email } });
         if (user) {


### PR DESCRIPTION
When signing in from a second browser, jwt signs data that comes from sequelize rather than the auth provider. By default this blob contains a bunch of table metadata and some circular references, so the sign fails. This diff asks sequelize to give back just the table data and strip out all the problematic metadata.