### PR TITLE
Add CSS modules :local pseudo selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
         true,
         {
           "ignorePseudoClasses": [
-            "global"
+            "global",
+            "local"
           ]
         }
       ]


### PR DESCRIPTION
Along with the :global selector, CSS modules supports :local as an integral part of their library.