### PR TITLE
Corrected shell script typo in .md

### DIFF
--- a/docs/how-to-configure-text-editors.md
+++ b/docs/how-to-configure-text-editors.md
@@ -35,7 +35,7 @@ Install atom packages
 * [react](https://atom.io/packages/react)
 
 ```shell
-apm install linter linter-eslint react linter-stylelint
+npm install linter linter-eslint react linter-stylelint
 ```
 
 Install local npm packages


### PR DESCRIPTION
I noticed that one of the scripts mentioned "apm" when it should be "npm". That is all.