### PR TITLE
Fix Request-type object passing to localFetch

### DIFF
--- a/src/core/fetch/fetch.server.js
+++ b/src/core/fetch/fetch.server.js
@@ -14,6 +14,10 @@ import { host } from '../../config';
 fetch.Promise = Promise;
 Response.Promise = Promise;
 
+/**
+ * @param {string} url
+ * @returns {string}
+ */
 function localUrl(url) {
   if (url.startsWith('//')) {
     return `https:${url}`;
@@ -26,8 +30,24 @@ function localUrl(url) {
   return `http://${host}${url}`;
 }
 
-function localFetch(url, options) {
-  return fetch(localUrl(url), options);
+/**
+ * @param {Request} req
+ * @returns {Request}
+ */
+function localRequest(req) {
+  return new Request(localUrl(req.url), req);
+}
+
+/**
+ * This method should handle both url+options and Request
+ * @param {string|Request} urlOrReq
+ * @param {Object} [options]
+ * @returns {Promise}
+ */
+function localFetch(urlOrReq, options) {
+  const isReq = urlOrReq instanceof Request;
+  const params = isReq ? [localRequest(urlOrReq)] : [localUrl(urlOrReq), options];
+  return fetch(...params);
 }
 
 export { localFetch as default, Request, Headers, Response };


### PR DESCRIPTION
Hello

It is impossible to import `Request` from `node-fetch` and pass this request as parameter to localFetch from `fetch.server.js`, however node-fetch support this since Feb 2016. This PR will fix this SSR issue taking into account relative urls.

So now able to write smth like this:
```javascript
import fetch, { Request, Headers } from '../core/fetch'

function prepare(method, path, data) {
  // prepare path and options here
  return new Request(path, options)
}

async function execute(req) {
  try {
    const response = await fetch(req)
    // ...
  }
  // ...
}

```