### PR TITLE
Dockerfile: use cache for yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM node:7.9.0-alpine
 # Set a working directory
 WORKDIR /usr/src/app
 
-# Copy application files
-COPY ./build /usr/src/app
+COPY ./build/package.json .
 
 # Install Node.js dependencies
 RUN yarn install --production --no-progress
+
+# Copy application files
+COPY ./build .
 
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
It is a small optimisation improvement for `dockerfile`. If there is no change to `package.json` between two builds, docker will use cache for creating `node_modules` folder instead of pulling it once again. 
Before this is merged, yarn installs `node_modules` for each build everytime. The result is you have to wait everytime.
After this is merged, you wait for yarn to install dependencies only when `package.json` file has been changed. The result is faster images builds. At the same time you can work with all other files. 

Example output:

```Sending build context to Docker daemon 179.5 MB
Step 1/6 : FROM node:7.9.0-alpine
 ---> 7fce0a61c1d6
Step 2/6 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 7493302cae38
Step 3/6 : COPY ./build/package.json .
 ---> Using cache
 ---> c22786e579e8
Step 4/6 : RUN yarn install --production --no-progress
 ---> Using cache
 ---> d822545f7c00
Step 5/6 : COPY ./build .
 ---> 4693695e099e
Removing intermediate container 727422c8396f
Step 6/6 : CMD node server.js
 ---> Running in f02d44037193
 ---> cd98c9e3d70b
Removing intermediate container f02d44037193
Successfully built cd98c9e3d70b```

