### PR TITLE
fix(server/jwt):handle 401 caused by secret change

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -54,6 +54,16 @@ app.use(expressJwt({
   credentialsRequired: false,
   getToken: req => req.cookies.id_token,
 }));
+// Error handler for express-jwt
+app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+  if (err instanceof Jwt401Error) {
+    console.error('[express-jwt-error]', req.cookies.id_token);
+    // `clearCookie`, otherwise user can't use web-app until cookie expires
+    res.clearCookie('id_token');
+  }
+  next(err);
+});
+
 app.use(passport.initialize());
 
 if (__DEV__) {
@@ -146,17 +156,6 @@ app.get('*', async (req, res, next) => {
 const pe = new PrettyError();
 pe.skipNodeFiles();
 pe.skipPackage('express');
-
-// express-jwt error handler
-app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
-  if (err instanceof Jwt401Error) {
-    console.error('[express-jwt]', req.cookies.id_token, pe.render(err));
-    res.clearCookie('id_token');
-    res.redirect('/');
-  } else {
-    next(err);
-  }
-});
 
 app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
   console.error(pe.render(err));

--- a/src/server.js
+++ b/src/server.js
@@ -60,11 +60,6 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     console.error('[express-jwt-error]', req.cookies.id_token);
     // `clearCookie`, otherwise user can't use web-app until cookie expires
     res.clearCookie('id_token');
-    const jwtError = new Error(err.message);
-    jwtError.status = err.status;
-    jwtError.name = err.name;
-    jwtError.stack = err.stack;
-    next(jwtError);
   } else {
     next(err);
   }

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@ import path from 'path';
 import express from 'express';
 import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
-import expressJwt from 'express-jwt';
+import expressJwt, { UnauthorizedError as Jwt401Error } from 'express-jwt';
 import expressGraphQL from 'express-graphql';
 import jwt from 'jsonwebtoken';
 import React from 'react';
@@ -146,6 +146,17 @@ app.get('*', async (req, res, next) => {
 const pe = new PrettyError();
 pe.skipNodeFiles();
 pe.skipPackage('express');
+
+// express-jwt error handler
+app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+  if (err instanceof Jwt401Error) {
+    console.error('[express-jwt]', req.cookies.id_token, pe.render(err));
+    res.clearCookie('id_token');
+    res.redirect('/');
+  } else {
+    next(err);
+  }
+});
 
 app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
   console.error(pe.render(err));

--- a/src/server.js
+++ b/src/server.js
@@ -60,8 +60,14 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     console.error('[express-jwt-error]', req.cookies.id_token);
     // `clearCookie`, otherwise user can't use web-app until cookie expires
     res.clearCookie('id_token');
+    const jwtError = new Error(err.message);
+    jwtError.status = err.status;
+    jwtError.name = err.name;
+    jwtError.stack = err.stack;
+    next(jwtError);
+  } else {
+    next(err);
   }
-  next(err);
 });
 
 app.use(passport.initialize());


### PR DESCRIPTION
When config `auth.jwt.secret` is changed, this `UnauthorizedError: invalid signature` error happenens.
It's very serious because it can't be recovered automatically after refresh. User must clear cookie to continue to use the app.
```
UnauthorizedError: invalid signature
  
  - index.js:101 
    [react-starter-kit]/[express-jwt]/lib/index.js:101:22
  
  - index.js:54 
    [react-starter-kit]/[express-jwt]/[jsonwebtoken]/index.js:54:18
  
  - next_tick.js:67 _combinedTickCallback
    internal/process/next_tick.js:67:7
  
  - next_tick.js:98 process._tickCallback
    internal/process/next_tick.js:98:9
```