### PR TITLE
Fix cookie issue when doing server rendering

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -101,7 +101,7 @@ app.get('*', async (req, res, next) => {
       // Universal HTTP client
       fetch: createFetch({
         baseUrl: config.api.serverUrl,
-        cookie: req.cookie,
+        cookie: req.headers.cookie,
       }),
     };
 


### PR DESCRIPTION
The cookie sent by `fetch` when doing server rendering should be the raw cookie string from client, not the js object transformed by `cookie-parser` middleware.