### PR TITLE
Facebook: request displayName profile field

### DIFF
--- a/src/passport.js
+++ b/src/passport.js
@@ -25,7 +25,7 @@ passport.use(new FacebookStrategy({
   clientID: config.auth.facebook.id,
   clientSecret: config.auth.facebook.secret,
   callbackURL: '/login/facebook/return',
-  profileFields: ['name', 'email', 'link', 'locale', 'timezone'],
+  profileFields: ['displayName', 'name', 'email', 'link', 'locale', 'timezone'],
   passReqToCallback: true,
 }, (req, accessToken, refreshToken, profile, done) => {
   /* eslint-disable no-underscore-dangle */


### PR DESCRIPTION
`profile.displayName` will be undefined when the displayName field is not explicitly requested.