### PR TITLE
Use yarn.lock when building docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM node:7.9.0-alpine
 WORKDIR /usr/src/app
 
 COPY ./build/package.json .
+COPY ./build/yarn.lock .
 
 # Install Node.js dependencies
 RUN yarn install --production --no-progress

--- a/tools/copy.js
+++ b/tools/copy.js
@@ -29,6 +29,7 @@ async function copy() {
       },
     }, null, 2)),
     copyFile('LICENSE.txt', 'build/LICENSE.txt'),
+    copyFile('yarn.lock', 'build/yarn.lock'),
     copyDir('public', 'build/public'),
   ]);
 


### PR DESCRIPTION
This is a small improvement, which makes building docker images consistent with the repository.

**Problem**: For now, if you want to build a docker image with the flag `--docker`, the dockerfile doesn't use `yarn.lock` file. In this case yarn needs to create lock file from scratch, which may well lead to situation, when there are different modules versions installed inside docker images from versions locked in committed `yarn.lock` file and installed locally.

```
Step 4/6 : RUN yarn install --production --no-progress
 ---> Running in d4382b3ff374
yarn install v0.23.2
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 30.04s.
```

**Expected behaviour**: Use the same `yarn.lock`, when building docker images.

**Solution**: Copy `yarn.lock` file before `yarn install` command is executed within dockerfile.

```
Step 4/7 : COPY ./build/yarn.lock .
 ---> 15bf3a4613a5
Removing intermediate container f471a96c78d2
Step 5/7 : RUN yarn install --production --no-progress
 ---> Running in dbc39e77afbb
yarn install v0.23.2
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 25.22s.
```
