### PR TITLE
[feature/apollo] Single source of graphql query

### DIFF
--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -13,6 +13,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
+import { ApolloClient } from 'apollo-client';
 import thunk from 'redux-thunk';
 import App from '../App';
 import Layout from './Layout';
@@ -24,9 +25,10 @@ const initialState = {};
 describe('Layout', () => {
   test('renders children correctly', () => {
     const store = mockStore(initialState);
+    const client = new ApolloClient();
     const wrapper = renderer
       .create(
-        <App context={{ insertCss: () => {}, store }}>
+        <App context={{ insertCss: () => {}, store, client, fetch: () => {} }}>
           <Layout>
             <div className="child" />
           </Layout>

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -9,12 +9,13 @@
 
 import React from 'react';
 import Home from './Home';
+import newsQuery from './news.graphql';
 import Layout from '../../components/Layout';
 
 async function action({ fetch }) {
   const resp = await fetch('/graphql', {
     body: JSON.stringify({
-      query: '{news{title,link,content}}',
+      query: newsQuery.loc.source.body,
     }),
   });
   const { data } = await resp.json();


### PR DESCRIPTION
If we are using same query for SSR and on the client site (eg. in refetchQueries) I think maintaining single query is easier and DRYer.