### PR TITLE
Use renderToString for server side React

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -155,7 +155,7 @@ app.get('*', async (req, res, next) => {
       apiUrl: config.api.clientUrl,
     };
 
-    const html = ReactDOM.renderToStaticMarkup(<Html {...data} />);
+    const html = ReactDOM.renderToString(<Html {...data} />);
     res.status(route.status || 200);
     res.send(`<!doctype html>${html}`);
   } catch (err) {


### PR DESCRIPTION
Output generated by renderToStaticMarkup is not suitable for hydration by ReactDOM.hydrate.

See https://reactjs.org/docs/react-dom-server.html#rendertostring

This causes problems when hydration output like:

```jsx
    const a = 'a';
    const b = 'b';
    const component = <select><option>{a} ({b})</option></select>; 
```

`renderToStaticMarkup()` gives:
`<select><option>a (b)</option></select>`

`renderToString()` gives:
`<select data-reactroot=""><option>a<!-- --> (<!-- -->b<!-- -->)</option></select>`

Hydrating the former gives:
`Warning: Text content did not match. Server: "a (b)" Client: "a"`

This happens because React expects each part of the dynamic contents of `<option>` to be a separate DOM textNode. `renderToString()` preserves this, `renderToStaticMarkup` doesn't, because it expects the output to not be used for hydrating.