### PR TITLE
Simplify server side webpack config

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -433,8 +433,7 @@ const serverConfig = {
           ...rule,
           options: {
             ...rule.options,
-            name: `public/assets/${rule.options.name}`,
-            publicPath: url => url.replace(/^public/, ''),
+            emitFile: false,
           },
         };
       }


### PR DESCRIPTION
we can use `emitFile: false` to make server side not to generate static files