### PR TITLE
[feature/react-intl] Convert LanguageSwitcher function into ES6 class and add default stylesheet

### DIFF
--- a/src/components/LanguageSwitcher/LanguageSwitcher.css
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.css
@@ -1,0 +1,14 @@
+/**
+ * React Starter Kit (https://www.reactstarterkit.com/)
+ *
+ * Copyright © 2014-present Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+@import '../variables.css';
+
+.root {
+  color: rgba(255, 255, 255, 0.6);
+}

--- a/src/components/LanguageSwitcher/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.js
@@ -2,48 +2,55 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import { connect } from 'react-redux';
 import { setLocale } from '../../actions/intl';
+import s from './LanguageSwitcher.css';
 
-function LanguageSwitcher({ currentLocale, availableLocales, setLocale }) {
-  const isSelected = locale => locale === currentLocale;
-  const localeDict = {
-    /* @intl-code-template '${lang}-${COUNTRY}': '${Name}', */
-    'en-US': 'English',
-    'cs-CZ': 'Česky',
-    /* @intl-code-template-end */
-  };
-  const localeName = locale => localeDict[locale] || locale;
-  return (
-    <div>
-      {availableLocales.map(locale =>
-        <span key={locale}>
-          {isSelected(locale)
-            ? <span>
-                {localeName(locale)}
-              </span>
-            : // github.com/yannickcr/eslint-plugin-react/issues/945
-              // eslint-disable-next-line react/jsx-indent
-              <a
-                href={`?lang=${locale}`}
-                onClick={e => {
-                  setLocale({ locale });
-                  e.preventDefault();
-                }}
-              >
-                {localeName(locale)}
-              </a>}{' '}
-        </span>,
-      )}
-    </div>
-  );
-}
-
-LanguageSwitcher.propTypes = {
-  currentLocale: PropTypes.string.isRequired,
-  availableLocales: PropTypes.arrayOf(PropTypes.string).isRequired,
-  setLocale: PropTypes.func.isRequired,
+const localeDict = {
+  /* @intl-code-template '${lang}-${COUNTRY}': '${Name}', */
+  'en-US': 'English',
+  'cs-CZ': 'Česky',
+  /* @intl-code-template-end */
 };
+
+class LanguageSwitcher extends React.Component {
+  static propTypes = {
+    currentLocale: PropTypes.string.isRequired,
+    availableLocales: PropTypes.arrayOf(PropTypes.string).isRequired,
+    setLocale: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const { currentLocale, availableLocales, setLocale } = this.props;
+    const isSelected = locale => locale === currentLocale;
+    const localeName = locale => localeDict[locale] || locale;
+
+    return (
+      <div className={s.root}>
+        {availableLocales.map(locale =>
+          <span key={locale}>
+            {isSelected(locale)
+              ? <span>
+                  {localeName(locale)}
+                </span>
+              : // github.com/yannickcr/eslint-plugin-react/issues/945
+                // eslint-disable-next-line react/jsx-indent
+                <a
+                  href={`?lang=${locale}`}
+                  onClick={e => {
+                    setLocale({ locale });
+                    e.preventDefault();
+                  }}
+                >
+                  {localeName(locale)}
+                </a>}{' '}
+          </span>,
+        )}
+      </div>
+    );
+  }
+}
 
 const mapState = state => ({
   availableLocales: state.runtime.availableLocales,
@@ -54,4 +61,4 @@ const mapDispatch = {
   setLocale,
 };
 
-export default connect(mapState, mapDispatch)(LanguageSwitcher);
+export default connect(mapState, mapDispatch)(withStyles(s)(LanguageSwitcher));


### PR DESCRIPTION
To comply other components syntax and example stylesheet.