### PR TITLE
Update webpack-dev-middleware configuration for v2

### DIFF
--- a/tools/start.js
+++ b/tools/start.js
@@ -129,7 +129,7 @@ async function start() {
   server.use(
     webpackDevMiddleware(clientCompiler, {
       publicPath: clientConfig.output.publicPath,
-      quiet: true,
+      logLevel: 'silent',
       watchOptions,
     }),
   );


### PR DESCRIPTION
Webpack-dev-middleware changed some options in version 2:
https://github.com/webpack/webpack-dev-middleware/releases/tag/v2.0.0

The change from `quiet: true` to `logLevel: 'silent'` should be applied to react-starter-kit.