### PR TITLE
Abort build when there are compilation errors

### DIFF
--- a/tools/bundle.js
+++ b/tools/bundle.js
@@ -21,6 +21,10 @@ function bundle() {
       }
 
       console.info(stats.toString(webpackConfig[0].stats));
+      if (stats.hasErrors()) {
+        return reject(new Error('Webpack compilation errors'));
+      }
+
       return resolve();
     });
   });


### PR DESCRIPTION
I accidentally pushed a build to production that contained webpack compilation errors. As can be read at https://webpack.js.org/api/node/#error-handling, the `err` parameter covers just a portion of the possible errors that are possible during webpack compilation.