### PR TITLE
[feature/Apollo] Log Apollo Ops in Development

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "apollo-link": "^1.0.7",
     "apollo-link-error": "^1.0.3",
     "apollo-link-http": "^1.3.2",
+    "apollo-link-logger": "^1.1.0",
     "apollo-link-schema": "^1.0.1",
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.2",

--- a/src/core/createApolloClient/createApolloClient.client.js
+++ b/src/core/createApolloClient/createApolloClient.client.js
@@ -3,6 +3,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { from } from 'apollo-link';
 import { onError } from 'apollo-link-error';
 import { HttpLink } from 'apollo-link-http';
+import apolloLogger from 'apollo-link-logger';
 
 const link = from([
   onError(({ graphQLErrors, networkError }) => {
@@ -14,6 +15,7 @@ const link = from([
       );
     if (networkError) console.warn(`[Network error]: ${networkError}`);
   }),
+  ...(__DEV__ ? [apolloLogger] : []),
   new HttpLink({
     uri: '/graphql',
     credentials: 'include',

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,10 @@ apollo-link-http@^1.3.2:
   dependencies:
     apollo-link "^1.0.7"
 
+apollo-link-logger@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/apollo-link-logger/-/apollo-link-logger-1.1.0.tgz#5f2220e5c0c6ebbaf6161a25921142fdb824efce"
+
 apollo-link-schema@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/apollo-link-schema/-/apollo-link-schema-1.0.1.tgz#d9db6343b1512373cc847188b5fb8708abd6235a"


### PR DESCRIPTION
Restores logging capability on all Apollo GraphQL operations while in development mode. 

The logging output is in the style of redux-logger, so the same as with redux ops, but also includes the time taken by the request.

![capture](https://user-images.githubusercontent.com/10257939/34631702-df35bb98-f22e-11e7-99ce-01525fd88bfa.PNG)
