### PR TITLE
Remove duplicate babel/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@babel/preset-stage-2": "7.0.0-beta.36",
     "assets-webpack-plugin": "^3.5.1",
     "autoprefixer": "^7.2.3",
-    "babel-core": "^7.0.0-0",
     "babel-eslint": "^8.1.2",
     "babel-jest": "^22.0.4",
     "babel-loader": "8.0.0-beta.0",


### PR DESCRIPTION
I was getting some errors that I traced back to the duplicate babel/core inclusion.

This was the error I was getting.

```shell
$ yarn start

yarn run v1.3.2
$ babel-node tools/run start
/Users/justin/repos/site2/tools/run.js:10
export function format(time) {
^^^^^^

SyntaxError: Unexpected token export
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:152:10)
    at Module._compile (module.js:624:28)
    at loader (/Users/justin/repos/site2/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/justin/repos/site2/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
    at Object.<anonymous> (/Users/justin/repos/site2/node_modules/babel-cli/lib/_babel-node.js:154:22)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Once I removed the duplicate babel/core from the `package.json` it started working again. 

I was also using `"babel-cli": "^6.26.0"` instead of `"@babel/cli": "^7.0.0-beta.32"` so my issue might have to do with that as well.

Thought it might still be valuable to remove the duplicated & old babel/core.
