### PR TITLE
Short circuit fetch for `/graphql` on SSR

### DIFF
--- a/src/createFetch.js
+++ b/src/createFetch.js
@@ -36,7 +36,7 @@ function createFetch(fetch: Fetch, { baseUrl, cookie, schema }: Options) {
     },
   };
 
-  return (url: string, options: any) => {
+  return async (url: string, options: any) => {
     const isGraphQL = url.startsWith('/graphql');
     if (schema && isGraphQL) {
       // We're SSR, so route the graphql internall to avoid latency
@@ -48,23 +48,24 @@ function createFetch(fetch: Fetch, { baseUrl, cookie, schema }: Options) {
         null,
         query.variables,
       );
-      return new Promise(resolve => resolve({
-        status: result.errors ? 400 : 200,
-        json: () =>
-          new Promise((resolveJson) => resolveJson(result)),
-      }));
+      return new Promise(resolve =>
+        resolve({
+          status: result.errors ? 400 : 200,
+          json: () => new Promise(resolveJson => resolveJson(result)),
+        }),
+      );
     }
     return isGraphQL || url.startsWith('/api')
       ? fetch(`${baseUrl}${url}`, {
-        ...defaults,
-        ...options,
-        headers: {
-          ...defaults.headers,
-          ...(options && options.headers),
-        },
-      })
+          ...defaults,
+          ...options,
+          headers: {
+            ...defaults.headers,
+            ...(options && options.headers),
+          },
+        })
       : fetch(url, options);
-  }
+  };
 }
 
 export default createFetch;

--- a/src/createFetch.js
+++ b/src/createFetch.js
@@ -8,6 +8,7 @@
  */
 
 /* @flow */
+import { graphql } from 'graphql';
 
 type Fetch = (url: string, options: ?any) => Promise<any>;
 
@@ -22,7 +23,7 @@ type Options = {
  * of boilerplate code in the application.
  * https://developer.mozilla.org/docs/Web/API/Fetch_API/Using_Fetch
  */
-function createFetch(fetch: Fetch, { baseUrl, cookie }: Options) {
+function createFetch(fetch: Fetch, { baseUrl, cookie, schema }: Options) {
   // NOTE: Tweak the default options to suite your application needs
   const defaults = {
     method: 'POST', // handy with GraphQL backends
@@ -35,17 +36,35 @@ function createFetch(fetch: Fetch, { baseUrl, cookie }: Options) {
     },
   };
 
-  return (url: string, options: any) =>
-    url.startsWith('/graphql') || url.startsWith('/api')
+  return (url: string, options: any) => {
+    const isGraphQL = url.startsWith('/graphql');
+    if (schema && isGraphQL) {
+      // We're SSR, so route the graphql internall to avoid latency
+      const query = JSON.parse(options.body);
+      const result = await graphql(
+        schema,
+        query.query,
+        { request: {} }, // fill in request vars needed by graphql
+        null,
+        query.variables,
+      );
+      return new Promise(resolve => resolve({
+        status: result.errors ? 500 : 200,
+        json: () =>
+          new Promise((resolveJson) => resolveJson(result)),
+      }));
+    }
+    return isGraphQL || url.startsWith('/api')
       ? fetch(`${baseUrl}${url}`, {
-          ...defaults,
-          ...options,
-          headers: {
-            ...defaults.headers,
-            ...(options && options.headers),
-          },
-        })
+        ...defaults,
+        ...options,
+        headers: {
+          ...defaults.headers,
+          ...(options && options.headers),
+        },
+      })
       : fetch(url, options);
+  }
 }
 
 export default createFetch;

--- a/src/createFetch.js
+++ b/src/createFetch.js
@@ -49,7 +49,7 @@ function createFetch(fetch: Fetch, { baseUrl, cookie, schema }: Options) {
         query.variables,
       );
       return new Promise(resolve => resolve({
-        status: result.errors ? 500 : 200,
+        status: result.errors ? 400 : 200,
         json: () =>
           new Promise((resolveJson) => resolveJson(result)),
       }));

--- a/src/server.js
+++ b/src/server.js
@@ -127,6 +127,7 @@ app.get('*', async (req, res, next) => {
       fetch: createFetch(fetch, {
         baseUrl: config.api.serverUrl,
         cookie: req.headers.cookie,
+        schema,
       }),
     };
 


### PR DESCRIPTION
The starter template with graphql uses node-fetch to route HTTP requests when doing SSR. For graphql queries, this leads to a decent bit of overhead as it issues HTTP requests when the request could be handled in the same process without the loopback http call. In our application, this leads to 50-100ms performance improvements per graphql query.

Since we are internally routing, mapping of request properties will need to be handled as needed. For example, we add a user to the request object based on the JWT, so that needs to be passed through. We accomplish that through additional args to the createFetch method.

Also, there is a very lightweight shim for the response object (json()) to support backwards compat.

This could be extended to do something similar for API calls.

Happy to make any requested changes.

Thanks for a great starter template.