### PR TITLE
Add a runtime warning when NODE_ENV is missing in release runs

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -461,7 +461,12 @@ const serverConfig = {
     // Adds a banner to the top of each generated chunk
     // https://webpack.js.org/plugins/banner-plugin/
     new webpack.BannerPlugin({
-      banner: 'require("source-map-support").install();',
+      banner: [
+        'require("source-map-support").install();',
+        !isDebug
+          ? 'if(process.env.NODE_ENV !== "production") { console.warn("You\'re running a release build without the NODE_ENV environment variable set to \'production\'.\\nThis will lead to suboptimal performance."); }'
+          : '',
+      ].join('\n'),
       raw: true,
       entryOnly: false,
     }),


### PR DESCRIPTION
I accidently forgot to set `NODE_ENV` to `"production"` in my production environment. React-Starter-Kit uses DefinePlugin to replace `NODE_ENV` with `"production"` at build time, but this only applies to the app code. Code like React looks at the present value of `NODE_ENV` to determine whether to load debug or production code. express also 

I propose that `BannerPlugin` is extended to issue a warning when server.js is started without `NODE_ENV` set to `"production"` when server.js is generated using `yarn build --release`.