### PR TITLE
Enable configuration of 'trust proxy', defaults to loopback

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,9 @@ module.exports = {
   // Node.js app
   port: process.env.PORT || 3000,
 
+  // https://expressjs.com/en/guide/behind-proxies.html
+  trustProxy: process.env.TRUST_PROXY || 'loopback',
+
   // API Gateway
   api: {
     // API URL to be used in the client-side code

--- a/src/server.js
+++ b/src/server.js
@@ -34,6 +34,12 @@ import config from './config';
 const app = express();
 
 //
+// If you are using proxy from external machine, you can set TRUST_PROXY env
+// Default is to trust proxy headers only from loopback interface.
+// -----------------------------------------------------------------------------
+app.set('trust proxy', config.trustProxy);
+
+//
 // Tell any CSS tooling (such as Material UI) to use all vendor prefixes if the
 // user agent is not known.
 // -----------------------------------------------------------------------------
@@ -71,9 +77,6 @@ app.use((err, req, res, next) => {
 
 app.use(passport.initialize());
 
-if (__DEV__) {
-  app.enable('trust proxy');
-}
 app.get(
   '/login/facebook',
   passport.authenticate('facebook', {


### PR DESCRIPTION
For application are more relevant IP addresses from outside.
Instead of seeing your proxy IP (mostly loopback) in the logs,
you can check IP of real client.
Note that if your application is visible from outside world,
you want know IP outside of your architecture.