### PR TITLE
Update version of express-graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.3",
     "express": "^4.16.2",
-    "express-graphql": "^0.6.11",
+    "express-graphql": "^0.6.12",
     "express-jwt": "^5.3.0",
     "graphql": "^0.12.3",
     "history": "^4.7.2",


### PR DESCRIPTION
Work with graphql 0.12+ without warning