### PR TITLE
fix(webpack): Fix Webpack compilation on Windows

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -17,7 +17,7 @@ import overrideRules from './lib/overrideRules';
 import pkg from '../package.json';
 
 const ROOT_DIR = path.resolve(__dirname, '..');
-const SRC_DIR = `${ROOT_DIR}/src`;
+const SRC_DIR = path.join(ROOT_DIR, 'src');
 const BUILD_DIR = `${ROOT_DIR}/build`;
 const NODE_MODULES_DIR = `${ROOT_DIR}/node_modules`;
 


### PR DESCRIPTION
Currently I get the following error while running `yarn start` or `yarn build`:

```
yarn run v1.5.1
$ babel-node tools/run build --release
[20:10:14] Starting 'build'...
[20:10:14] Starting 'clean'...
[20:10:14] Finished 'clean' after 29 ms
[20:10:14] Starting 'copy'...
[20:10:14] Finished 'copy' after 27 ms
[20:10:14] Starting 'bundle'...
Child client:
    Time: 1456ms
    Built at: 2018-3-24 20:10:16
     4 assets
    Entrypoint client = vendors.3bf78000.chunk.js vendors.3bf78000.chunk.js.map client.b3dfa204.js client.b3dfa204.js.map

    ERROR in ./src/client.js
    Module parse failed: Unexpected token (81:6)
    You may need an appropriate loader to handle this file type.
    |     const renderReactApp = isInitialRender ? ReactDOM.hydrate : ReactDOM.render;
    |     appInstance = renderReactApp(
    |       <App context={context}>{route.component}</App>,
    |       container,
    |       () => {
     @ multi @babel/polyfill ./src/client.js
Child server:
    Time: 106ms
    Built at: 2018-3-24 20:10:14
     2 assets
    Entrypoint server = server.js server.js.map

    ERROR in ./src/server.js
    Module parse failed: Unexpected token (162:6)
    You may need an appropriate loader to handle this file type.
    |     const data = { ...route };
    |     data.children = ReactDOM.renderToString(
    |       <App context={context}>{route.component}</App>,
    |     );
    |     data.styles = [{ id: 'css', cssText: [...css].join('') }];
     @ multi @babel/polyfill ./src/server.js
Error: Webpack compilation errors
    at C:\Projects\GitHub\react-starter-kit\tools\bundle.js:36:23
    at finalCallback (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\MultiCompiler.js:243:39)
    at runWithDependencies.err (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\MultiCompiler.js:261:6)
    at done (C:\Projects\GitHub\react-starter-kit\node_modules\neo-async\async.js:2875:13)
    at runCompilers (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\MultiCompiler.js:173:48)
    at err (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\MultiCompiler.js:180:7)
    at compiler.run (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\MultiCompiler.js:256:7)
    at finalCallback (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\Compiler.js:152:39)
    at hooks.done.callAsync.err (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\Compiler.js:168:13)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (C:\Projects\GitHub\react-starter-kit\node_modules\tapable\lib\HookCodeFactory.js:24:12), <anonymous>:24:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (C:\Projects\GitHub\react-starter-kit\node_modules\tapable\lib\Hook.js:35:21)
    at onCompiled (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\Compiler.js:166:21)
    at hooks.afterCompile.callAsync.err (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\Compiler.js:486:14)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (C:\Projects\GitHub\react-starter-kit\node_modules\tapable\lib\HookCodeFactory.js:24:12), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (C:\Projects\GitHub\react-starter-kit\node_modules\tapable\lib\Hook.js:35:21)
    at compilation.seal.err (C:\Projects\GitHub\react-starter-kit\node_modules\webpack\lib\Compiler.js:483:30)
error An unexpected error occurred: "Command failed.
```

For some reason JSX isn't parsed. Changing one line from simple string concatenation to `path.join()` fixed it. I have no idea why the other lines didn't need to be changed. If you like those lines to use `path.join()` also for consistency, I can change them. The current change appears the only one necessary.