### PR TITLE
Remove unused dependency bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "dependencies": {
     "@babel/polyfill": "^7.0.0-beta.44",
-    "bluebird": "^3.5.1",
     "body-parser": "^1.18.2",
     "classnames": "^2.2.5",
     "cookie-parser": "^1.4.3",


### PR DESCRIPTION
It looks like we stopped using it in 1ed83b6 (#1237).