### PR TITLE
Remove unused dependency core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "body-parser": "^1.18.2",
     "classnames": "^2.2.5",
     "cookie-parser": "^1.4.3",
-    "core-js": "^2.5.4",
     "express": "^4.16.3",
     "express-graphql": "^0.6.12",
     "express-jwt": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,10 +2224,6 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.4.tgz#f2c8bf181f2a80b92f360121429ce63a2f0aeae0"
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
It was added in 79e5575 (https://github.com/kriasoft/react-starter-kit/pull/452) to work around an npm issue,
but we instead use yarn as of 78868e6 (https://github.com/kriasoft/react-starter-kit/pull/1044).