### PR TITLE
Configure serverUrl from Heroku Dyno Metadata

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,8 @@ module.exports = {
     // API URL to be used in the server-side code
     serverUrl:
       process.env.API_SERVER_URL ||
+      (process.env.HEROKU_APP_NAME &&
+        `https://${process.env.HEROKU_APP_NAME}.herokuapp.com`) ||
       `http://localhost:${process.env.PORT || 3000}`,
   },
 


### PR DESCRIPTION
When Dyno Metadata is enabled, `serverUrl` can be automatically
determined.

https://devcenter.heroku.com/articles/dyno-metadata

I needed to do this because the `localhost` URL wasn't working for me. I'm not sure why that was the case, but this fixed it.