### PR TITLE
Add build/start scripts for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node build/server.js

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "clean": "babel-node tools/run clean",
     "copy": "babel-node tools/run copy",
     "bundle": "babel-node tools/run bundle",
+    "heroku-postbuild": "yarn run build --release",
     "build": "babel-node tools/run build",
     "build-stats": "yarn run build --release --analyse",
     "deploy": "babel-node tools/run deploy",


### PR DESCRIPTION
This should make it possible to simply push to Heroku and have it
build/run the app, instead of needing to run `yarn deploy` manually.

Similarly, things like review apps and auto-deploy from master should
also work.

https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps
https://devcenter.heroku.com/articles/nodejs-support#default-web-process-type
https://devcenter.heroku.com/articles/github-integration