### PR TITLE
Add feature for multi-column layouts on pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,36 @@ and newcomers to the industry.
   <sup><a href="https://x-team.com/join/?utm_source=reactstarterkit&utm_medium=github-link&utm_campaign=reactstarterkit-june">Hiring</a></sup>
 </p>
 
-
 ### Getting Started
 
-  * Follow the [getting started guide](./docs/getting-started.md) to download and run the project
-    ([Node.js](https://nodejs.org/) >= 6.5)
-  * Check the [code recipes](./docs/recipes) used in this boilerplate, or share yours
-
+- Follow the [getting started guide](./docs/getting-started.md) to download and run the project
+  ([Node.js](https://nodejs.org/) >= 6.5)
+- Check the [code recipes](./docs/recipes) used in this boilerplate, or share yours
 
 ### Customization
 
 The `master` branch of React Starter Kit doesn't include a Flux implementation or any other
-advanced integrations. Nevertheless, we have some integrations available to you in *feature*
+advanced integrations. Nevertheless, we have some integrations available to you in _feature_
 branches that you can use either as a reference or merge into your project:
 
-  * [feature/redux](https://github.com/kriasoft/react-starter-kit/tree/feature/redux) ([PR](https://github.com/kriasoft/react-starter-kit/pull/1084))
-    — isomorphic Redux by [Pavel Lang](https://github.com/langpavel)
-    (see [how to integrate Redux](./docs/recipes/how-to-integrate-redux.md)) (based on `master`)
-  * [feature/apollo](https://github.com/kriasoft/react-starter-kit/tree/feature/apollo) ([PR](https://github.com/kriasoft/react-starter-kit/pull/1147))
-    — isomorphic Apollo Client by [Pavel Lang](https://github.com/langpavel)
-    (see [Tracking PR #1147](https://github.com/kriasoft/react-starter-kit/pull/1147)) (based on `feature/redux`)
-  * [feature/react-intl](https://github.com/kriasoft/react-starter-kit/tree/feature/react-intl) ([PR](https://github.com/kriasoft/react-starter-kit/pull/1135))
-    — isomorphic Redux and React Intl by [Pavel Lang](https://github.com/langpavel)
-    (see [how to integrate React Intl](./docs/recipes/how-to-integrate-react-intl.md)) (based on `feature/apollo`)
+- [feature/redux](https://github.com/kriasoft/react-starter-kit/tree/feature/redux) ([PR](https://github.com/kriasoft/react-starter-kit/pull/1084))
+  — isomorphic Redux by [Pavel Lang](https://github.com/langpavel)
+  (see [how to integrate Redux](./docs/recipes/how-to-integrate-redux.md)) (based on `master`)
+- [feature/apollo](https://github.com/kriasoft/react-starter-kit/tree/feature/apollo) ([PR](https://github.com/kriasoft/react-starter-kit/pull/1147))
+  — isomorphic Apollo Client by [Pavel Lang](https://github.com/langpavel)
+  (see [Tracking PR #1147](https://github.com/kriasoft/react-starter-kit/pull/1147)) (based on `feature/redux`)
+- [feature/react-intl](https://github.com/kriasoft/react-starter-kit/tree/feature/react-intl) ([PR](https://github.com/kriasoft/react-starter-kit/pull/1135))
+  — isomorphic Redux and React Intl by [Pavel Lang](https://github.com/langpavel)
+  (see [how to integrate React Intl](./docs/recipes/how-to-integrate-react-intl.md)) (based on `feature/apollo`)
+- [feature/multi-column-layout](https://github.com/kriasoft/react-starter-kit/tree/feature/multi-column-layout)([PR](https://github.com/kriasoft/react-starter-kit/pull/1135))
+  - Add global or page-specific content to the left and/or the right of the main content in adjacent column(s) of page(s) using the `Page` component.
+    (see [how to create multi-column pages](./docs/recipes/how-to-create-multi-column-pages.md))
 
 You can see status of most reasonable merge combination as [PRs labeled as `TRACKING`](https://github.com/kriasoft/react-starter-kit/labels/TRACKING)
 
 If you think that any of these features should be on `master`, or vice versa, some features should
 removed from the `master` branch, please [let us know](https://gitter.im/kriasoft/react-starter-kit).
 We love your feedback!
-
 
 ### Comparison
 
@@ -149,7 +149,6 @@ We love your feedback!
   </tr>
 </table>
 
-
 ### Backers
 
 ♥ React Starter Kit? Help us keep it alive by donating funds to cover project
@@ -178,7 +177,6 @@ expenses via [OpenCollective](https://opencollective.com/react-starter-kit) or
   <img src="https://opencollective.com/static/images/become_backer.svg" width="64" height="64" alt="">
 </a>
 
-
 ### How to Contribute
 
 Anyone and everyone is welcome to [contribute](CONTRIBUTING.md) to this project. The best way to
@@ -188,35 +186,31 @@ start is by checking our [open issues](https://github.com/kriasoft/react-starter
 participate in discussions, upvote or downvote the issues you like or dislike, send [pull
 requests](CONTRIBUTING.md#pull-requests).
 
-
 ### Learn More
 
-  * [Getting Started with React.js](http://facebook.github.io/react/)
-  * [Getting Started with GraphQL and Relay](https://quip.com/oLxzA1gTsJsE)
-  * [React.js Questions on StackOverflow](http://stackoverflow.com/questions/tagged/reactjs)
-  * [React.js Discussion Board](https://discuss.reactjs.org/)
-  * [Flux Architecture for Building User Interfaces](http://facebook.github.io/flux/)
-  * [Enzyme — JavaScript Testing utilities for React](http://airbnb.io/enzyme/)
-  * [Flow — A static type checker for JavaScript](http://flowtype.org/)
-  * [The Future of React](https://github.com/reactjs/react-future)
-  * [Learn ES6](https://babeljs.io/docs/learn-es6/), [ES6 Features](https://github.com/lukehoban/es6features#readme)
-
+- [Getting Started with React.js](http://facebook.github.io/react/)
+- [Getting Started with GraphQL and Relay](https://quip.com/oLxzA1gTsJsE)
+- [React.js Questions on StackOverflow](http://stackoverflow.com/questions/tagged/reactjs)
+- [React.js Discussion Board](https://discuss.reactjs.org/)
+- [Flux Architecture for Building User Interfaces](http://facebook.github.io/flux/)
+- [Enzyme — JavaScript Testing utilities for React](http://airbnb.io/enzyme/)
+- [Flow — A static type checker for JavaScript](http://flowtype.org/)
+- [The Future of React](https://github.com/reactjs/react-future)
+- [Learn ES6](https://babeljs.io/docs/learn-es6/), [ES6 Features](https://github.com/lukehoban/es6features#readme)
 
 ### Related Projects
 
-  * [GraphQL Starter Kit](https://github.com/kriasoft/graphql-starter-kit) — Boilerplate for building data APIs with Node.js, JavaScript (via Babel) and GraphQL
-  * [Membership Database](https://github.com/membership/membership.db) — SQL schema boilerplate for user accounts, profiles, roles, and auth claims
-  * [Babel Starter Kit](https://github.com/kriasoft/babel-starter-kit) — Boilerplate for authoring JavaScript/React.js libraries
-
+- [GraphQL Starter Kit](https://github.com/kriasoft/graphql-starter-kit) — Boilerplate for building data APIs with Node.js, JavaScript (via Babel) and GraphQL
+- [Membership Database](https://github.com/membership/membership.db) — SQL schema boilerplate for user accounts, profiles, roles, and auth claims
+- [Babel Starter Kit](https://github.com/kriasoft/babel-starter-kit) — Boilerplate for authoring JavaScript/React.js libraries
 
 ### Support
 
-  * [#react-starter-kit](http://stackoverflow.com/questions/tagged/react-starter-kit) on Stack Overflow — Questions and answers
-  * [#react-starter-kit](https://gitter.im/kriasoft/react-starter-kit) on Gitter — Watch announcements, share ideas and feedback
-  * [GitHub issues](https://github.com/kriasoft/react-starter-kit/issues), or [Scrum board](https://waffle.io/kriasoft/react-starter-kit) — File issues, send feature requests
-  * [appear.in/react](https://appear.in/react) — Open hours! Exchange ideas and experiences (React, GraphQL, startups and pet projects)
-  * [@koistya](https://twitter.com/koistya) on [Codementor](https://www.codementor.io/koistya), or [Skype](http://hatscripts.com/addskype?koistya) — Private consulting
-
+- [#react-starter-kit](http://stackoverflow.com/questions/tagged/react-starter-kit) on Stack Overflow — Questions and answers
+- [#react-starter-kit](https://gitter.im/kriasoft/react-starter-kit) on Gitter — Watch announcements, share ideas and feedback
+- [GitHub issues](https://github.com/kriasoft/react-starter-kit/issues), or [Scrum board](https://waffle.io/kriasoft/react-starter-kit) — File issues, send feature requests
+- [appear.in/react](https://appear.in/react) — Open hours! Exchange ideas and experiences (React, GraphQL, startups and pet projects)
+- [@koistya](https://twitter.com/koistya) on [Codementor](https://www.codementor.io/koistya), or [Skype](http://hatscripts.com/addskype?koistya) — Private consulting
 
 ### License
 
@@ -226,6 +220,7 @@ file. The documentation to the project is licensed under the
 [CC BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/) license.
 
 ---
+
 Made with ♥ by Konstantin Tarkus ([@koistya](https://twitter.com/koistya)) and [contributors](https://github.com/kriasoft/react-starter-kit/graphs/contributors)
 
 [rsk]: https://www.reactstarterkit.com

--- a/docs/recipes/how-to-create-multi-column-pages.md
+++ b/docs/recipes/how-to-create-multi-column-pages.md
@@ -1,0 +1,49 @@
+## How to Create Multi-column Pages
+
+This feature uses [CSS Grid Layout Module Level 1](https://www.w3.org/TR/css-grid-1/)
+to lay out the page into two or three columns
+
+### Adding Multiple Columns
+
+1.  Merge `feature/multi-column-layout` branch with git.
+
+2.  Run `yarn install` (the only dependency added is [lodash-inflection](https://www.npmjs.com/package/lodash-inflection) for the `titleize` function)
+
+3.  [See the About Us Page](../../src/routes/about/index.js) for an example of using the default behavior,
+    which is to have columns to the left and right of the main page content, which [uses the global column content](../../src/routes/global-columns)
+    meant to be used across multiple pages as the default content for multi-column pages.
+
+#### Customizing Column Layout and Content
+
+Put the following in the **index.js** file of your custom page directory [under the routes directory](../../src/routes)\:
+
+```js
+import React from 'react';
+import Layout from '../../components/Layout';
+import Page from '../../components/Page';
+import yourPage from './yourPage.md';
+import withColumns, { defaultColumnData } from '../../../tools/lib/columns';
+
+// A page with only a left column having custom content
+// Change 'left-column' to 'right-column' if you want only a right column
+// Create file left-column.md in your page directory under the routes directory
+//
+// You can also provide custom content for both columns by adding both keys
+// below and creating the corresponding files
+function action() {
+  withColumns(yourPage, {
+    leftColumnKey: 'left-column',
+    columnsKey: 'name-of-your-page-directory-under-routes',
+  });
+  return {
+    chunks: [yourPage.key],
+    component: (
+      <Layout>
+        <Page {...yourPage} />
+      </Layout>
+    ),
+  };
+}
+
+export default action;
+```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "history": "^4.7.2",
     "isomorphic-style-loader": "^4.0.0",
     "jsonwebtoken": "^8.3.0",
+    "lodash-inflection": "^1.5.0",
     "node-fetch": "^2.1.2",
     "normalize.css": "^8.0.0",
     "passport": "^0.4.0",

--- a/src/components/Page/Page.css
+++ b/src/components/Page/Page.css
@@ -18,4 +18,59 @@
   margin: 0 auto;
   padding: 0 0 40px;
   max-width: var(--max-content-width);
+
+  &::after {
+    content: '';
+    clear: both;
+    display: table;
+  }
+}
+
+/* Grid fall-backs for <= IE 10 */
+.sectionMainColumnWide,
+.sectionMainColumnNarrow,
+.sectionLeftColumn,
+.sectionRightColumn {
+  float: left;
+}
+
+.sectionMainColumnWide {
+  width: var(--main-column-wide-width);
+}
+
+.sectionMainColumnNarrow {
+  width: var(--main-column-narrow-width);
+}
+
+.sectionLeftColumn {
+  width: var(--left-column-width);
+}
+
+.sectionRightColumn {
+  width: var(--right-column-width);
+}
+
+@supports (display: grid) {
+  .container {
+    display: grid;
+
+    &.leftColumn {
+      grid-template-columns: 1fr 3fr;
+    }
+
+    &.rightColumn {
+      grid-template-columns: 3fr 1fr;
+    }
+
+    &.multiColumn {
+      grid-template-columns: 1fr 2fr 1fr;
+    }
+  }
+
+  .sectionMainColumnWide,
+  .sectionMainColumnNarrow,
+  .sectionLeftColumn,
+  .sectionRightColumn {
+    width: unset;
+  }
 }

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -10,24 +10,86 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import classNames from 'classnames';
+import { titleize } from 'lodash-inflection';
+// This is necessary because some classes are interpolated, not unused
+// eslint-disable-next-line css-modules/no-unused-class
 import s from './Page.css';
 
 class Page extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     html: PropTypes.string.isRequired,
+    /* eslint-disable */
+    leftColumnTitle: PropTypes.string,
+    leftColumnHtml: PropTypes.string,
+    rightColumnTitle: PropTypes.string,
+    rightColumnHtml: PropTypes.string,
+    /* eslint-enable */
   };
-
+  static defaultProps = {
+    leftColumnTitle: '',
+    leftColumnHtml: '',
+    rightColumnTitle: '',
+    rightColumnHtml: '',
+  };
+  renderColumnTitle(side) {
+    const titleKey = `${side}ColumnTitle`;
+    if (!this.props[titleKey]) return '';
+    return (
+      <h2
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: this.props[titleKey] }}
+      />
+    );
+  }
+  renderColumnHtml(side) {
+    const columnHtml = this.props[`${side}ColumnHtml`];
+    if (!columnHtml) return '';
+    return (
+      <section className={s[`section${titleize(side)}Column`]}>
+        {this.renderColumnTitle(side)}
+        <article
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: columnHtml }}
+        />
+      </section>
+    );
+  }
   render() {
     const { title, html } = this.props;
+    const hasAdjacentColumns =
+      this.props.leftColumnHtml && this.props.rightColumnHtml;
+    const hasOnlyLeftColumn = !hasAdjacentColumns && this.props.leftColumnHtml;
+    const hasOnlyRightColumn =
+      !hasAdjacentColumns && this.props.rightColumnHtml;
     return (
       <div className={s.root}>
-        <div className={s.container}>
-          <h1>{title}</h1>
-          <div
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: html }}
-          />
+        <div
+          // The linter complains because these classes are nested
+          /* eslint-disable css-modules/no-undef-class */
+          className={classNames(s.container, {
+            [s.multiColumn]: hasAdjacentColumns,
+            [s.leftColumn]: hasOnlyLeftColumn,
+            [s.rightColumn]: hasOnlyRightColumn,
+          })}
+          /* eslint-enable css-modules/no-undef-class */
+        >
+          {this.renderColumnHtml('left')}
+          <section
+            className={classNames({
+              [s.sectionMainColumnNarrow]: hasAdjacentColumns,
+              [s.sectionMainColumnWide]:
+                hasOnlyRightColumn || hasOnlyLeftColumn,
+            })}
+          >
+            <h1>{title}</h1>
+            <div
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          </section>
+          {this.renderColumnHtml('right')}
         </div>
       </div>
     );

--- a/src/components/Page/Page.test.js
+++ b/src/components/Page/Page.test.js
@@ -1,0 +1,85 @@
+/**
+ * React Starter Kit (https://www.reactstarterkit.com/)
+ *
+ * Copyright © 2014-present Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+/* eslint-env jest */
+/* eslint-disable padded-blocks, no-unused-expressions */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import App from '../App';
+import Layout from '../Layout';
+import Page from './Page';
+import { defaultColumnData } from '../../../tools/lib/columns';
+
+describe('Page', () => {
+  let about = {};
+  let columnData = {};
+  beforeEach(() => {
+    about = {
+      title: 'About Us',
+      component: 'ContentPage',
+      key: 'about',
+      html:
+        '<p>Lorem ipsum dolor sit amet, consectetur adipisc…or arcu eget arcu. Vestibulum vel quam enim.</p>',
+    };
+    columnData = {
+      leftColumnTitle: 'Whoa, a title!',
+      leftColumnHtml: '<p>You will never escape me!</p>',
+      rightColumnTitle: 'The correct column title',
+      rightColumnHtml: '<ul><li>A list with one item</li></ul>',
+    };
+  });
+  test('renders page without columns correctly', () => {
+    const wrapper = renderer.create(
+      <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
+        <Layout>
+          <Page {...about} />
+        </Layout>
+      </App>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+  test('renders multi column page correctly', () => {
+    Object.assign(about, defaultColumnData, columnData);
+    const wrapper = renderer.create(
+      <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
+        <Layout>
+          <Page {...about} />
+        </Layout>
+      </App>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+  test('renders left column page correctly', () => {
+    delete columnData.rightColumnHtml;
+    delete columnData.rightColumnTitle;
+    Object.assign(about, defaultColumnData, columnData);
+    const wrapper = renderer.create(
+      <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
+        <Layout>
+          <Page {...about} />
+        </Layout>
+      </App>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+  test('renders right column page correctly', () => {
+    delete columnData.leftColumnHtml;
+    delete columnData.leftColumnTitle;
+    Object.assign(about, defaultColumnData, columnData);
+    const wrapper = renderer.create(
+      <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
+        <Layout>
+          <Page {...about} />
+        </Layout>
+      </App>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/src/components/Page/__snapshots__/Page.test.js.snap
@@ -1,0 +1,861 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page renders left column page correctly 1`] = `
+<div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <div
+        className="root"
+        role="navigation"
+      >
+        <a
+          className="link"
+          href="/about"
+          onClick={[Function]}
+        >
+          About
+        </a>
+        <a
+          className="link"
+          href="/contact"
+          onClick={[Function]}
+        >
+          Contact
+        </a>
+        <span
+          className="spacer"
+        >
+           | 
+        </span>
+        <a
+          className="link"
+          href="/login"
+          onClick={[Function]}
+        >
+          Log in
+        </a>
+        <span
+          className="spacer"
+        >
+          or
+        </span>
+        <a
+          className="link highlight"
+          href="/register"
+          onClick={[Function]}
+        >
+          Sign up
+        </a>
+      </div>
+      <a
+        className="brand"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          alt="React"
+          height="38"
+          src="logo-small.png"
+          srcSet="logo-small@2x.png 2x"
+          width="38"
+        />
+        <span
+          className="brandTxt"
+        >
+          Your Company
+        </span>
+      </a>
+      <div
+        className="banner"
+      >
+        <h1
+          className="bannerTitle"
+        >
+          React
+        </h1>
+        <p
+          className="bannerDesc"
+        >
+          Complex web apps made easy
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container leftColumn"
+    >
+      <section
+        className="sectionLeftColumn"
+      >
+        <h2
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Whoa, a title!",
+            }
+          }
+        />
+        <article
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>You will never escape me!</p>",
+            }
+          }
+        />
+      </section>
+      <section
+        className="sectionMainColumnWide"
+      >
+        <h1>
+          About Us
+        </h1>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipisc…or arcu eget arcu. Vestibulum vel quam enim.</p>",
+            }
+          }
+        />
+      </section>
+      
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <a
+        className="link"
+        href="https://gitter.im/kriasoft/react-starter-kit"
+      >
+        Ask a question
+      </a>
+      <span
+        className="spacer"
+      >
+        |
+      </span>
+      <a
+        className="link"
+        href="https://github.com/kriasoft/react-starter-kit/issues/new"
+      >
+        Report an issue
+      </a>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <span
+        className="text"
+      >
+        © Your Company
+      </span>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/"
+        onClick={[Function]}
+      >
+        Home
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/admin"
+        onClick={[Function]}
+      >
+        Admin
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/privacy"
+        onClick={[Function]}
+      >
+        Privacy
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/not-found"
+        onClick={[Function]}
+      >
+        Not Found
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Page renders multi column page correctly 1`] = `
+<div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <div
+        className="root"
+        role="navigation"
+      >
+        <a
+          className="link"
+          href="/about"
+          onClick={[Function]}
+        >
+          About
+        </a>
+        <a
+          className="link"
+          href="/contact"
+          onClick={[Function]}
+        >
+          Contact
+        </a>
+        <span
+          className="spacer"
+        >
+           | 
+        </span>
+        <a
+          className="link"
+          href="/login"
+          onClick={[Function]}
+        >
+          Log in
+        </a>
+        <span
+          className="spacer"
+        >
+          or
+        </span>
+        <a
+          className="link highlight"
+          href="/register"
+          onClick={[Function]}
+        >
+          Sign up
+        </a>
+      </div>
+      <a
+        className="brand"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          alt="React"
+          height="38"
+          src="logo-small.png"
+          srcSet="logo-small@2x.png 2x"
+          width="38"
+        />
+        <span
+          className="brandTxt"
+        >
+          Your Company
+        </span>
+      </a>
+      <div
+        className="banner"
+      >
+        <h1
+          className="bannerTitle"
+        >
+          React
+        </h1>
+        <p
+          className="bannerDesc"
+        >
+          Complex web apps made easy
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container multiColumn"
+    >
+      <section
+        className="sectionLeftColumn"
+      >
+        <h2
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Whoa, a title!",
+            }
+          }
+        />
+        <article
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>You will never escape me!</p>",
+            }
+          }
+        />
+      </section>
+      <section
+        className="sectionMainColumnNarrow"
+      >
+        <h1>
+          About Us
+        </h1>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipisc…or arcu eget arcu. Vestibulum vel quam enim.</p>",
+            }
+          }
+        />
+      </section>
+      <section
+        className="sectionRightColumn"
+      >
+        <h2
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "The correct column title",
+            }
+          }
+        />
+        <article
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<ul><li>A list with one item</li></ul>",
+            }
+          }
+        />
+      </section>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <a
+        className="link"
+        href="https://gitter.im/kriasoft/react-starter-kit"
+      >
+        Ask a question
+      </a>
+      <span
+        className="spacer"
+      >
+        |
+      </span>
+      <a
+        className="link"
+        href="https://github.com/kriasoft/react-starter-kit/issues/new"
+      >
+        Report an issue
+      </a>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <span
+        className="text"
+      >
+        © Your Company
+      </span>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/"
+        onClick={[Function]}
+      >
+        Home
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/admin"
+        onClick={[Function]}
+      >
+        Admin
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/privacy"
+        onClick={[Function]}
+      >
+        Privacy
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/not-found"
+        onClick={[Function]}
+      >
+        Not Found
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Page renders page without columns correctly 1`] = `
+<div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <div
+        className="root"
+        role="navigation"
+      >
+        <a
+          className="link"
+          href="/about"
+          onClick={[Function]}
+        >
+          About
+        </a>
+        <a
+          className="link"
+          href="/contact"
+          onClick={[Function]}
+        >
+          Contact
+        </a>
+        <span
+          className="spacer"
+        >
+           | 
+        </span>
+        <a
+          className="link"
+          href="/login"
+          onClick={[Function]}
+        >
+          Log in
+        </a>
+        <span
+          className="spacer"
+        >
+          or
+        </span>
+        <a
+          className="link highlight"
+          href="/register"
+          onClick={[Function]}
+        >
+          Sign up
+        </a>
+      </div>
+      <a
+        className="brand"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          alt="React"
+          height="38"
+          src="logo-small.png"
+          srcSet="logo-small@2x.png 2x"
+          width="38"
+        />
+        <span
+          className="brandTxt"
+        >
+          Your Company
+        </span>
+      </a>
+      <div
+        className="banner"
+      >
+        <h1
+          className="bannerTitle"
+        >
+          React
+        </h1>
+        <p
+          className="bannerDesc"
+        >
+          Complex web apps made easy
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      
+      <section
+        className=""
+      >
+        <h1>
+          About Us
+        </h1>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipisc…or arcu eget arcu. Vestibulum vel quam enim.</p>",
+            }
+          }
+        />
+      </section>
+      
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <a
+        className="link"
+        href="https://gitter.im/kriasoft/react-starter-kit"
+      >
+        Ask a question
+      </a>
+      <span
+        className="spacer"
+      >
+        |
+      </span>
+      <a
+        className="link"
+        href="https://github.com/kriasoft/react-starter-kit/issues/new"
+      >
+        Report an issue
+      </a>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <span
+        className="text"
+      >
+        © Your Company
+      </span>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/"
+        onClick={[Function]}
+      >
+        Home
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/admin"
+        onClick={[Function]}
+      >
+        Admin
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/privacy"
+        onClick={[Function]}
+      >
+        Privacy
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/not-found"
+        onClick={[Function]}
+      >
+        Not Found
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Page renders right column page correctly 1`] = `
+<div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <div
+        className="root"
+        role="navigation"
+      >
+        <a
+          className="link"
+          href="/about"
+          onClick={[Function]}
+        >
+          About
+        </a>
+        <a
+          className="link"
+          href="/contact"
+          onClick={[Function]}
+        >
+          Contact
+        </a>
+        <span
+          className="spacer"
+        >
+           | 
+        </span>
+        <a
+          className="link"
+          href="/login"
+          onClick={[Function]}
+        >
+          Log in
+        </a>
+        <span
+          className="spacer"
+        >
+          or
+        </span>
+        <a
+          className="link highlight"
+          href="/register"
+          onClick={[Function]}
+        >
+          Sign up
+        </a>
+      </div>
+      <a
+        className="brand"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          alt="React"
+          height="38"
+          src="logo-small.png"
+          srcSet="logo-small@2x.png 2x"
+          width="38"
+        />
+        <span
+          className="brandTxt"
+        >
+          Your Company
+        </span>
+      </a>
+      <div
+        className="banner"
+      >
+        <h1
+          className="bannerTitle"
+        >
+          React
+        </h1>
+        <p
+          className="bannerDesc"
+        >
+          Complex web apps made easy
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container rightColumn"
+    >
+      
+      <section
+        className="sectionMainColumnWide"
+      >
+        <h1>
+          About Us
+        </h1>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipisc…or arcu eget arcu. Vestibulum vel quam enim.</p>",
+            }
+          }
+        />
+      </section>
+      <section
+        className="sectionRightColumn"
+      >
+        <h2
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "The correct column title",
+            }
+          }
+        />
+        <article
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<ul><li>A list with one item</li></ul>",
+            }
+          }
+        />
+      </section>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <a
+        className="link"
+        href="https://gitter.im/kriasoft/react-starter-kit"
+      >
+        Ask a question
+      </a>
+      <span
+        className="spacer"
+      >
+        |
+      </span>
+      <a
+        className="link"
+        href="https://github.com/kriasoft/react-starter-kit/issues/new"
+      >
+        Report an issue
+      </a>
+    </div>
+  </div>
+  <div
+    className="root"
+  >
+    <div
+      className="container"
+    >
+      <span
+        className="text"
+      >
+        © Your Company
+      </span>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/"
+        onClick={[Function]}
+      >
+        Home
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/admin"
+        onClick={[Function]}
+      >
+        Admin
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/privacy"
+        onClick={[Function]}
+      >
+        Privacy
+      </a>
+      <span
+        className="spacer"
+      >
+        ·
+      </span>
+      <a
+        className="link"
+        href="/not-found"
+        onClick={[Function]}
+      >
+        Not Found
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/variables.css
+++ b/src/components/variables.css
@@ -19,6 +19,10 @@
    * ======================================================================== */
 
   --max-content-width: 1000px;
+  --left-column-width: 25%;
+  --right-column-width: 25%;
+  --main-column-wide-width: 75%;
+  --main-column-narrow-width: 50%;
 
   /*
    * Media queries breakpoints

--- a/src/routes/about/index.js
+++ b/src/routes/about/index.js
@@ -11,11 +11,20 @@ import React from 'react';
 import Layout from '../../components/Layout';
 import Page from '../../components/Page';
 import about from './about.md';
+import withColumns, { defaultColumnData } from '../../../tools/lib/columns';
 
 function action() {
+  // Displays a wide left column and narrow right column
+  // withColumns(about, {rightColumnKey: 'right-column',
+  //  columnsKey: 'global-columns' }
+  // Displays a wide right column and narrow left column
+  // withColumns(about, {leftColumnKey: 'left-column',
+  //
+  // Displays both columns using the column data found in the global-columns
+  // directory under the routes directory
+  withColumns(about, defaultColumnData);
   return {
-    chunks: ['about'],
-    title: about.title,
+    chunks: [about.key],
     component: (
       <Layout>
         <Page {...about} />

--- a/src/routes/about/left-column.md
+++ b/src/routes/about/left-column.md
@@ -1,0 +1,10 @@
+---
+title: Left Column
+component: ContentPage
+---
+
+### List of Items
+
+- Item One
+- Item Two
+- Item Three

--- a/src/routes/about/right-column.md
+++ b/src/routes/about/right-column.md
@@ -1,0 +1,10 @@
+---
+title: Right Column
+component: ContentPage
+---
+
+### List of Items
+
+- Item One
+- Item Two
+- Item Three

--- a/src/routes/global-columns/left-column.md
+++ b/src/routes/global-columns/left-column.md
@@ -1,0 +1,10 @@
+---
+title: Left Column
+component: ContentPage
+---
+
+### List of Items
+
+- Item One
+- Item Two
+- Item Three

--- a/src/routes/global-columns/right-column.md
+++ b/src/routes/global-columns/right-column.md
@@ -1,0 +1,10 @@
+---
+title: Right Column
+component: ContentPage
+---
+
+### List of Items
+
+- Item One
+- Item Two
+- Item Three

--- a/tools/lib/columns.js
+++ b/tools/lib/columns.js
@@ -1,0 +1,33 @@
+function getColumn(key, columnKey, columnsKey) {
+  if (!columnKey) return {};
+  let pageData = {};
+  const routeKey = columnsKey || key;
+  // eslint-disable-next-line import/no-dynamic-require,global-require
+  const page = require(`../../src/routes/${routeKey}/${columnKey}.md`);
+  if (columnKey.startsWith('left')) {
+    const { title: leftColumnTitle, html: leftColumnHtml, key: colKey } = {
+      ...page,
+    };
+    pageData = { leftColumnTitle, leftColumnHtml, colKey };
+  } else {
+    const { title: rightColumnTitle, html: rightColumnHtml, key: colKey } = {
+      ...page,
+    };
+    pageData = { rightColumnTitle, rightColumnHtml, colKey };
+  }
+  return pageData;
+}
+const withColumns = (page, { columnsKey, leftColumnKey, rightColumnKey }) => {
+  const key = columnsKey || page.key;
+  Object.assign(
+    page,
+    getColumn(key, leftColumnKey, columnsKey),
+    getColumn(key, rightColumnKey, columnsKey),
+  );
+};
+export const defaultColumnData = {
+  leftColumnKey: 'left-column',
+  rightColumnKey: 'right-column',
+  columnsKey: 'global-columns',
+};
+export default withColumns;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,6 +5477,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-inflection@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lodash-inflection/-/lodash-inflection-1.5.0.tgz#344e5a8030882d51af98e0d613bb0547c8b7ddc7"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"


### PR DESCRIPTION
This feature lets a user optionally add columns on the right and left sides of the main content of pages in the `routes` directories with custom content for each column or they can use content specified in the `routes/global-columns` directory, which is a place for content that the user might want to appear the same on many pages.

**Some Things to Consider**:

Perhaps, in the future the following might be possible:

- Only including the fallback styles if the browser doesn't support the CSS Grid spec a la the talk [CSS Grid in Production](https://www.youtube.com/watch?v=_BCiiE31D5M&list=PLUS3uVC08ZaqVEGFkl_dS_3FUzILkOIzA) by Benjamin De Cock at dotCSS (16:05)  Not that `componentDidUpdate` isn't working for some reason in any version of Internet Explorer at the moment (this might be where the technique above is used).
- Add some default grid styling so that developers can have nice defaults even if they don't know CSS Grid
- This feature has been tested in all of the browsers listed in `browserslist` except for Android
- Media queries could be introduced to make three column layouts more responsive by showing the main content at the top of the page and maybe put the columns' content below it?
- Optimize by replacing `lodash-inflection` usage by creating a `string-utils.js` module in the project that has only the `titleize` function being currently being used.

**Note**: the auto-formatting changes to the README markdown were made by automated tasks that ran when I committed from command-line.