### PR TITLE
Using fragment instead of the div tag

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -25,12 +25,12 @@ class Layout extends React.Component {
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <Header />
         {this.props.children}
         <Feedback />
         <Footer />
-      </div>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
Hi there,

Since we are using the latest version of React.js then we can use the Fragment feature from now on. And I think it will be helped other users for using this awesome feature in their codes.