### PR TITLE
Jest.config: added a mock higher order component for isomorphic-style

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -62,8 +62,6 @@ module.exports = {
   // A map from regular expressions to module names that allow to stub out resources,
   // like images or styles with a single module.
   moduleNameMapper: {
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      '<rootDir>/tools/mocks//staticAssetMock.js',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
     'isomorphic-style-loader/lib/withStyles':
       '<rootDir>/tools/mocks/withStylesMock.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -62,7 +62,11 @@ module.exports = {
   // A map from regular expressions to module names that allow to stub out resources,
   // like images or styles with a single module.
   moduleNameMapper: {
-    '\\.(css|less|styl|scss|sass|sss)$': 'identity-obj-proxy',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/tools/mocks//staticAssetMock.js',
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    'isomorphic-style-loader/lib/withStyles':
+      '<rootDir>/tools/mocks/withStylesMock.js',
   },
 
   // modulePathIgnorePatterns: // [array<string>]

--- a/tools/mocks/staticAssetMock.js
+++ b/tools/mocks/staticAssetMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/tools/mocks/withStylesMock.js
+++ b/tools/mocks/withStylesMock.js
@@ -1,0 +1,1 @@
+module.exports = () => component => component;


### PR DESCRIPTION
Whenever the higher order component **isomorphic-style-loader** is used to inject styles to a component, the main default export cannot be imported with enzyme. A solution to this is to only import the base component (and not the default component). This solves some of the problems. 

However, if we try to **mount** a component (instead of **shallow** rendering), and if any of the children use withStyles from isomorphic-style-loader, we again face the same problem. As a result, a lot of the scenarios fail.

This has been an issue, which was reported several times:

[Issue](https://github.com/kriasoft/react-starter-kit/issues/378)
[Issue](https://github.com/kriasoft/isomorphic-style-loader/issues/130)

There is a straightforward solution to solve this concern (which was also discussed in one of issues), I also wrote a [medium](https://medium.com/@m.izadmehr/react-starter-kit-testing-isomorphic-style-loader-with-jest-and-enzyme-fd361b0591f0) article discussing the details of the changes:

Inside jest.config.js, there is an option called moduleNameMapper, which can be used to stub-out resources or mock them. And we add a field, to mock all instances of imports of isomorphic-style-loader, with a simple mock function.

I think it is a great idea to add the required changes in the jest.config.js file by default.

