### PR TITLE
Fix styles error in Home.css and deprecation warnings

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -12,7 +12,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import deepForceUpdate from 'react-deep-force-update';
 import queryString from 'query-string';
-import { createPath } from 'history/PathUtils';
+import { createPath } from 'history';
 import App from './components/App';
 import createFetch from './createFetch';
 import history from './history';

--- a/src/history.js
+++ b/src/history.js
@@ -7,7 +7,7 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 
 // Navigation manager, e.g. history.push('/home')
 // https://github.com/mjackson/history

--- a/src/routes/home/Home.css
+++ b/src/routes/home/Home.css
@@ -28,22 +28,20 @@
   font-size: 1.5rem;
 }
 
-.newsDesc {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: 1.125rem;
-  }
+.newsDesc h1,
+.newsDesc h2,
+.newsDesc h3,
+.newsDesc h4,
+.newsDesc h5,
+.newsDesc h6 {
+  font-size: 1.125rem;
+}
 
-  pre {
-    white-space: pre-wrap;
-    font-size: 0.875rem;
-  }
+.newsDesc pre {
+  white-space: pre-wrap;
+  font-size: 0.875rem;
+}
 
-  img {
-    max-width: 100%;
-  }
+.newsDesc img {
+  max-width: 100%;
 }


### PR DESCRIPTION
Here should be a valid CSS instead of SCSS so that Webstorm doesn't show an error. The second commit fixes console warnings: history/createBrowserHistory deprecated and history/PathUtils deprecated.