### PR TITLE
Remove mocha form docs (getting started)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,11 +139,11 @@ $ yarn run lint
 To launch unit tests:
 
 ```shell
-$ yarn run test          # Run unit tests with Mocha
+$ yarn run test          # Run unit tests with Jest
 $ yarn run test:watch    # Launch unit test runner and start watching for changes
 ```
 
-By default, [Mocha](https://mochajs.org/) test runner is looking for test files
+By default, [Jest](https://jestjs.io/) test runner is looking for test files
 matching the `src/**/*.test.js` pattern. Take a look at
 `src/components/Layout/Layout.test.js` as an example.
 


### PR DESCRIPTION
# Remove mocha form docs (getting started)

This PR removes the last mentions of Mocha in the docs, addressing the following issue #1529. I checked and the only other mention of Mocha in the whole project left is in the changelog.

Explanation about the naming of the files `Jest` looks for is still valid so I didn't need to change that.