### PR TITLE
Stop supporting Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - 'stable'
+  - '12'
   - '10'
   - '8'
-  - '6'
 env:
   - CXX=g++-4.8
 addons:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and newcomers to the industry.
 ### Getting Started
 
 - Follow the [getting started guide](./docs/getting-started.md) to download and run the project
-  ([Node.js](https://nodejs.org/) >= 6.9)
+  ([Node.js](https://nodejs.org/) >= 8.16.2)
 - Check the [code recipes](./docs/recipes) used in this boilerplate, or share yours
 
 ### Customization

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ### Requirements
 
 - Mac OS X, Windows, or Linux
-- [Yarn](https://yarnpkg.com/) package + [Node.js](https://nodejs.org/) v6.9 or
+- [Yarn](https://yarnpkg.com/) package + [Node.js](https://nodejs.org/) v8.16.2 or
   newer
 - Text editor or IDE pre-configured with React/JSX/Flow/ESlint
   ([learn more](./how-to-configure-text-editors.md))

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=6.13.1",
-    "npm": ">=3.10.10"
+    "node": ">=8.16.2",
+    "npm": ">=6.4.1"
   },
   "browserslist": [
     ">1%",


### PR DESCRIPTION
* [Node v6 has already ended being maintained by April 2019](https://nodejs.org/en/blog/release/v6.9.0/)
* Some dependencies stops supporting Node v6
    * [eslint-loader](https://travis-ci.org/kriasoft/react-starter-kit/builds/606828978?utm_source=github_status&utm_medium=notification)
    * [lint-staged](https://travis-ci.org/kriasoft/react-starter-kit/builds/606829247?utm_source=github_status&utm_medium=notification)
* By the end of 2019, v8 ends by the way