### PR TITLE
Use test-watch instead of test:watch

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,7 +140,7 @@ To launch unit tests:
 
 ```shell
 $ yarn run test          # Run unit tests with Jest
-$ yarn run test:watch    # Launch unit test runner and start watching for changes
+$ yarn run test-watch    # Launch unit test runner and start watching for changes
 ```
 
 By default, [Jest](https://jestjs.io/) test runner is looking for test files


### PR DESCRIPTION
According to the read me it should go:

yarn run test-watch             # Run unit tests in watch mode