### PR TITLE
simplify code contributions + reviews via fully automating the dev setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: yarn install && yarn run build
+    command: yarn run start
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,12 @@ forked repo, check that it meets these guidelines:
 - Run `yarn test` to make sure that your code style is OK and there are no any regression bugs.
 - When contributing to an opt-in feature, apply the `[feature/...]` tag as a prefix to your PR title
 
+### Online one-click setup for contributing
+
+You can use Gitpod(an online IDE which is free for Open Source) for working on issues and making Prs to this project. With a single click it will launch a workspace and automatically: clone the `react-starter-kit`, install the dependencies, run `yarn build` and `yarn start`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 #### Style Guide
 
 Our linter will catch most styling issues that may exist in your code. You can check the status


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `react-starter-kit` repo.
- install the dependencies.
- run `yarn build`.
- start the server via `yarn start`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/react-starter-kit

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/98568307-c778ee80-22d2-11eb-8e38-a976a7f21121.png)



