### PR TITLE
refactor: `useAuthCallback()` improvements

### DIFF
--- a/app/core/firebase.ts
+++ b/app/core/firebase.ts
@@ -1,9 +1,8 @@
 /* SPDX-FileCopyrightText: 2014-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-import { FirebaseError, initializeApp, type FirebaseApp } from "firebase/app";
+import { initializeApp, type FirebaseApp } from "firebase/app";
 import {
-  AuthErrorCodes,
   FacebookAuthProvider,
   getAuth,
   GoogleAuthProvider,
@@ -11,14 +10,7 @@ import {
   SignInMethod,
   signInWithPopup,
   type Auth,
-  type User,
   type UserCredential,
-} from "firebase/auth";
-export {
-  updateCurrentUser,
-  updateEmail,
-  updatePassword,
-  updateProfile,
 } from "firebase/auth";
 
 export const app = initializeApp({
@@ -50,17 +42,6 @@ export function signIn(options: LoginOptions): Promise<UserCredential> {
   }
 
   throw new Error(`Not supported: ${options.method}`);
-}
-
-/**
- * Returns the currently signed-in user or throws an error.
- * @throws {FirebaseError}
- */
-export function getCurrentUser(): User {
-  if (!auth.currentUser) {
-    throw new FirebaseError(AuthErrorCodes.NULL_USER, "Not authenticated.");
-  }
-  return auth.currentUser;
 }
 
 export const SignInMethods = [


### PR DESCRIPTION
- Add `me` of type `User` as the first argument to `useAuthCallback(callback)`'s callback function
- Update Account Settings page to use this updated React hook (see `app/routes/Settings.tsx`)
- Update input state example on the Account Settings page
- Remove `getCurrentUser()` method from `app/core/firebase.ts`

#### Usage example

```tsx
import * as React from "react";
import { updateProfile } from "firebase/auth";
import { useAuthCallback } from "../core/auth.js";

function Example(): JSX.Element {
  const [{ input }] = useState();

  // Opens a login dialog if user is not authenticated before executing the callback function
  const saveProfile = useAuthCallback(async (me) => {
    // If calling `updateProfile(..)` throws an authentication error, popup a login dialog and retry
    await updateProfile(me, input);
  }, [input]);
  
  ...
}
```