### PR TITLE
fix: Add an example GCP project ID

### DIFF
--- a/env/.local.env
+++ b/env/.local.env
@@ -11,8 +11,8 @@ API_ORIGIN=https://api-mcfytwakla-uc.a.run.app
 
 # Google Cloud
 # https://console.cloud.google.com/
-GOOGLE_CLOUD_PROJECT=
-GOOGLE_CLOUD_REGION=
+GOOGLE_CLOUD_PROJECT=kriasoft
+GOOGLE_CLOUD_REGION=us-central1
 
 # Firebase
 # https://console.firebase.google.com/


### PR DESCRIPTION
Add an example project ID to make Firebase Auth work out of the box without any code changes after cloning the repo even before a new GCP / Firebsae project is configured for the app.

Fixes #2006 