### PR TITLE
feat: Add API endpoint boilerplate

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,6 +67,7 @@ module.exports = {
     "import/resolver": {
       typescript: {
         project: [
+          "api/tsconfig.json",
           "app/tsconfig.json",
           "edge/tsconfig.json",
           "scripts/tsconfig.json",

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
       - run: yarn tsc --build
 
       # Test
+      - run: yarn workspace api test
       - run: yarn workspace app test
       - run: yarn workspace edge test
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /*/dist/
 
 # Yarn package manager with PnP
-# https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+# https://yarnpkg.com/getting-started/qa/#which-files-should-be-gitignored
 .pnp.*
 .yarn/*
 !.yarn/patches

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Be sure to join our [Discord channel](https://discord.com/invite/2nKEnKq) for as
 
 `├──`[`.github`](.github) — GitHub configuration including CI/CD workflows<br>
 `├──`[`.vscode`](.vscode) — VSCode settings including code snippets, recommended extensions etc.<br>
+`├──`[`api`](./api) — The API edge endpoint<br>
 `├──`[`app`](./app) — Web application front-end built with [React](https://reactjs.org/) and [Material UI](https://mui.com/core/)<br>
 `├──`[`edge`](./edge) — Cloudflare Workers (CDN) edge endpoint<br>
 `├──`[`env`](./env) — Application settings, API keys, etc.<br>
@@ -39,12 +40,9 @@ Be sure to join our [Discord channel](https://discord.com/invite/2nKEnKq) for as
 
 ## Tech Stack
 
-- [React](https://reactjs.org/), [React Router](https://reactrouter.com/), [Recoil](https://recoiljs.org/),
-  [Emotion](https://emotion.sh/), [Material UI](https://next.material-ui.com/),
-  [Firebase Authentication](https://firebase.google.com/docs/auth)
-- [Vite](https://vitejs.dev/), [Vitest](https://vitejs.dev/),
-  [TypeScript](https://www.typescriptlang.org/), [ESLint](https://eslint.org/),
-  [Prettier](https://prettier.io/), [Yarn](https://yarnpkg.com/) with PnP
+- [React](https://reactjs.org/), [React Router](https://reactrouter.com/), [Recoil](https://recoiljs.org/), [Emotion](https://emotion.sh/), [Material UI](https://next.material-ui.com/), [Firebase Authentication](https://firebase.google.com/docs/auth)
+- [Cloudflare Workers](https://workers.cloudflare.com/), [Vite](https://vitejs.dev/), [Vitest](https://vitejs.dev/),
+  [TypeScript](https://www.typescriptlang.org/), [ESLint](https://eslint.org/), [Prettier](https://prettier.io/), [Yarn](https://yarnpkg.com/) with PnP
 
 ## Requirements
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
-# CDN edge endpoint
+# API Endpoint
 
-CDN edge endpoint powered by [Cloudflare Workers](https://workers.cloudflare.com/) that serves the front-end app.
+GraphQL or RESTful API endpoint to be used by the front-end app.
 
 ## Directory Structure
 
@@ -15,9 +15,8 @@ CDN edge endpoint powered by [Cloudflare Workers](https://workers.cloudflare.com
 ## Getting Started
 
 ```
-$ yarn workspace app build
-$ yarn workspace edge build
-$ yarn workspace edge deploy [--env #0]
+$ yarn workspace api build
+$ yarn workspace api deploy [--env #0]
 ```
 
 ## Scripts

--- a/api/global.d.ts
+++ b/api/global.d.ts
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2014-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+declare type Bindings = {
+  APP_ENV: "local" | "test" | "prod";
+  APP_NAME: string;
+  APP_HOSTNAME: string;
+  GOOGLE_CLOUD_CREDENTIALS: string;
+};
+
+declare type Env = {
+  Bindings: Bindings;
+};
+
+declare const bindings: Bindings;
+
+declare function getMiniflareBindings<T = Bindings>(): T;

--- a/api/index.test.ts
+++ b/api/index.test.ts
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2014-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { expect, test } from "vitest";
+import app from "./index.js";
+
+test("GET /api/people/1", async () => {
+  const req = new Request("http://0.0.0.0/api/people/1");
+  const res = await app.fetch(req, bindings);
+  const body = await res.json();
+
+  expect({ status: res.status, body }).toEqual({
+    status: 200,
+    body: expect.objectContaining({
+      name: "Luke Skywalker",
+      url: "https://swapi.dev/api/people/1/",
+    }),
+  });
+});

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,30 @@
+/* SPDX-FileCopyrightText: 2014-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { Hono } from "hono";
+
+const app = new Hono<Env>();
+
+// An example of forwarding HTTP requests to a 3rd party API
+app.use("*", async ({ req }) => {
+  const { pathname, search } = new URL(req.url);
+  const targetUrl = `https://swapi.dev${pathname}${search}`;
+  const targetReq = new Request(targetUrl, req);
+  targetReq.headers.set("Accept", "application/json");
+  return await fetch(targetReq);
+});
+
+app.onError((err, ctx) => {
+  return ctx.json(
+    {
+      message: (err as Error).message ?? "Application Error",
+      stack: ctx.env.APP_ENV === "prod" ? undefined : (err as Error).stack,
+    },
+    500,
+    {
+      "Content-Type": "application/json",
+    },
+  );
+});
+
+export default app;

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest",
+    "coverage": "vitest run --coverage",
+    "deploy": "node ../scripts/wrangler.js publish"
+  },
+  "dependencies": {
+    "hono": "^3.0.1"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20230221.0",
+    "dotenv": "^16.0.3",
+    "toml": "^3.0.0",
+    "typescript": "^4.9.5",
+    "vite": "^4.1.4",
+    "vitest": "^0.28.5"
+  }
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types", "vite/client"],
+    "outDir": "../.cache/typescript-api"
+  },
+  "include": ["**/*.ts", "**/*.json"],
+  "exclude": ["dist/**/*"]
+}

--- a/api/vite.config.ts
+++ b/api/vite.config.ts
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2020-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { readFileSync } from "node:fs";
+import { parse } from "toml";
+import { defineConfig } from "vitest/config";
+
+const config = parse(readFileSync("./wrangler.toml", "utf8"));
+
+export default defineConfig({
+  cacheDir: "../.cache/vite-api",
+  build: {
+    lib: {
+      name: "api",
+      entry: "index.ts",
+      fileName: "index",
+      formats: ["es"],
+    },
+  },
+  define: {
+    bindings: JSON.stringify(config.vars),
+  },
+});

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -1,0 +1,31 @@
+# Cloudflare Workers configuration
+# https://developers.cloudflare.com/workers/wrangler/configuration/
+
+name = "caia-api"
+main = "index.js"
+
+# https://developers.cloudflare.com/workers/platform/compatibility-dates/
+compatibility_date = "2022-11-30"
+
+account_id = "3334c6b5a421ca85aea19d886d81b333"
+
+routes = [
+  { pattern = "caia.com/api/*", zone_id = "b660e5a49031a2482c473690204734d7" },
+  { pattern = "caia.com/auth/*", zone_id = "b660e5a49031a2482c473690204734d7" },
+]
+
+rules = [
+  { type = "ESModule", globs = ["dist/*.js"] },
+  { type = "Text", globs = ["dist/*.md"], fallthrough = true }
+]
+
+[vars]
+APP_ENV = "prod"
+APP_NAME = "caia"
+APP_HOSTNAME = "caia.app"
+
+# [secrets]
+# GOOGLE_CLOUD_CREDENTIALS
+
+[env.test]
+name = "caia-api-test"

--- a/app/README.md
+++ b/app/README.md
@@ -1,4 +1,4 @@
-# Web Application (Front-end)
+# Web Application (front-end)
 
 ## Directory Structure
 
@@ -6,12 +6,36 @@
 `├──`[`core`](./core) — Core modules, React hooks, customized theme, etc.<br>
 `├──`[`dialogs`](./dialogs) — React components implementing modal dialogs<br>
 `├──`[`icons`](./icons) — Custom icon React components<br>
-`├──`[`menus`](./menus) — React components implementing popup menus<br>
+`├──`[`layout`](./layout) — Layout related components<br>
 `├──`[`public`](./public) — Static assets such as robots.txt, index.html etc.<br>
 `├──`[`routes`](./routes) — Application routes and page (screen) components<br>
+`├──`[`theme`](./theme) — Customized Material UI theme<br>
 `├──`[`global.d.ts`](./global.d.ts) — Global TypeScript declarations<br>
 `├──`[`index.html`](./index.html) — HTML page containing application entry point<br>
 `├──`[`index.tsx`](./index.tsx) — Single-page application (SPA) entry point<br>
 `├──`[`package.json`](./package.json) — Workspace settings and NPM dependencies<br>
 `├──`[`tsconfig.ts`](./tsconfig.json) — TypeScript configuration<br>
 `└──`[`vite.config.ts`](./vite.config.ts) — JavaScript bundler configuration ([docs](https://vitejs.dev/config/))<br>
+
+## Getting Started
+
+```
+$ yarn workspace app start
+```
+
+## Scripts
+
+- `start [--force]` — Launch the app in development mode
+- `build` — Build the app for production
+- `preview` — Preview the production build
+- `test` — Run unit tests
+- `coverage` — Run unit tests with enabled coverage report
+- `deploy [--env #0]` — Deploy the app to Cloudflare (CDN)
+
+## References
+
+- https://beta.reactjs.org/ — React.js documentation
+- https://mui.com/core/ — Material UI library documentation
+- https://www.typescriptlang.org/ — TypeScript reference
+- https://vitejs.dev/ — Front-end tooling (bundler)
+- https://vitest.dev/ — Unit test framework

--- a/app/index.html
+++ b/app/index.html
@@ -13,12 +13,17 @@
     <meta property="og:type" content="" />
     <meta property="og:url" content="" />
     <meta property="og:image" content="" />
+    <meta name="theme-color" content="#fafafa" />
 
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/logo192.png" />
 
     <link rel="manifest" href="/site.manifest" />
-    <meta name="theme-color" content="#fafafa" />
+
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/app/layout/components/AppToolbar.tsx
+++ b/app/layout/components/AppToolbar.tsx
@@ -11,11 +11,11 @@ import {
   IconButton,
   Link,
   Toolbar,
-  Typography,
 } from "@mui/material";
 import * as React from "react";
 import { Link as NavLink } from "../../common/Link.js";
 import { useCurrentUser } from "../../core/auth.js";
+import { Logo } from "./Logo.js";
 import { NotificationsMenu } from "./NotificationsMenu.js";
 import { ThemeButton } from "./ThemeButton.js";
 import { UserMenu } from "./UserMenu.js";
@@ -56,11 +56,9 @@ export function AppToolbar(props: AppToolbarProps): JSX.Element {
       <Toolbar>
         {/* App name / logo */}
 
-        <Typography variant="h1" sx={{ fontSize: "1.5rem", fontWeight: 500 }}>
-          <Link color="inherit" underline="none" href="/" component={NavLink}>
-            {import.meta.env.VITE_APP_NAME}
-          </Link>
-        </Typography>
+        <Link color="inherit" underline="none" href="/" component={NavLink}>
+          <Logo />
+        </Link>
 
         <span style={{ flexGrow: 1 }} />
 
@@ -129,7 +127,7 @@ export function AppToolbar(props: AppToolbarProps): JSX.Element {
             component={NavLink}
             variant="text"
             href="/login"
-            color="primary"
+            color="inherit"
             children="Log in"
           />
         )}
@@ -138,7 +136,7 @@ export function AppToolbar(props: AppToolbarProps): JSX.Element {
             component={NavLink}
             variant="outlined"
             href="/signup"
-            color="primary"
+            color="inherit"
             children="Create an account"
           />
         )}

--- a/app/layout/components/Logo.tsx
+++ b/app/layout/components/Logo.tsx
@@ -8,7 +8,13 @@ export function Logo(props: TypographyProps): JSX.Element {
 
   return (
     <Typography
-      sx={{ ...sx, fontSize: "1.5rem", fontWeight: 500 }}
+      sx={{
+        ...sx,
+        display: "flex",
+        alignItems: "center",
+        fontSize: "1.5rem",
+        fontWeight: 500,
+      }}
       variant="h1"
       {...other}
     >

--- a/app/layout/components/UserMenu.tsx
+++ b/app/layout/components/UserMenu.tsx
@@ -34,7 +34,7 @@ export function UserMenu(props: UserMenuProps): JSX.Element {
       MenuListProps={{ ...MenuListProps, dense: true }}
       {...other}
     >
-      <MenuItem component={NavLink} to="/account" onClick={close}>
+      <MenuItem component={NavLink} to="/settings" onClick={close}>
         <ListItemIcon sx={{ minWidth: 40 }} children={<Settings />} />
         <ListItemText primary="Account Details" />
       </MenuItem>

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "coverage": "vitest --coverage",
-    "deploy": "echo \"Not implemented\"; exit 1",
+    "deploy": "yarn workspace edge deploy",
     "app:start": "yarn workspace app start",
     "app:build": "yarn workspace app build",
     "app:preview": "yarn workspace app preview",
@@ -31,6 +31,7 @@
     "recoil": "^0.7.6"
   },
   "devDependencies": {
+    "@babel/core": "^7.21.0",
     "@emotion/babel-plugin": "^11.10.6",
     "@types/node": "^18.14.0",
     "@types/react": "^18.0.28",

--- a/app/routes/auth/Login.tsx
+++ b/app/routes/auth/Login.tsx
@@ -12,7 +12,6 @@ import {
 } from "@mui/material";
 import { useLocation } from "react-router-dom";
 import { AuthIcon } from "../../icons/AuthIcon.js";
-import { useTheme } from "../../theme/index.js";
 import {
   Props,
   useHandleChange,
@@ -30,7 +29,6 @@ import { Notice } from "./Notice.js";
  *    https://www.notion.so/signup
  */
 export default function Login(props: Props): JSX.Element {
-  const lightTheme = useTheme("light");
   const [state, setState] = useState(props);
   const handleChange = useHandleChange(setState);
   const handleSignIn = useHandleSignIn(setState);
@@ -144,8 +142,8 @@ export default function Login(props: Props): JSX.Element {
 
       <Button
         sx={{
-          color: lightTheme.palette.text.primary,
-          backgroundColor: "white",
+          backgroundColor: (theme) =>
+            theme.palette.mode === "light" ? "white" : undefined,
           order: isSignUp ? undefined : -2,
         }}
         color="inherit"
@@ -161,8 +159,8 @@ export default function Login(props: Props): JSX.Element {
 
       <Button
         sx={{
-          color: lightTheme.palette.text.primary,
-          backgroundColor: "white",
+          backgroundColor: (theme) =>
+            theme.palette.mode === "light" ? "white" : undefined,
           order: isSignUp ? undefined : -2,
         }}
         color="inherit"
@@ -178,8 +176,8 @@ export default function Login(props: Props): JSX.Element {
 
       <Button
         sx={{
-          color: lightTheme.palette.text.primary,
-          backgroundColor: "white",
+          backgroundColor: (theme) =>
+            theme.palette.mode === "light" ? "white" : undefined,
           order: isSignUp ? undefined : -2,
         }}
         color="inherit"
@@ -187,7 +185,7 @@ export default function Login(props: Props): JSX.Element {
         variant="outlined"
         size="large"
         children="Continue as anonymous"
-        startIcon={<AuthIcon variant="anonymous" />}
+        startIcon={<AuthIcon color="inherit" variant="anonymous" />}
         onClick={handleSignIn}
         data-method="anonymous"
         fullWidth

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -42,7 +42,10 @@ export const router = createBrowserRouter([
       {
         path: "settings",
         element: <SettingsLayout />,
-        children: [{ path: "account", element: <AccountDetails /> }],
+        children: [
+          { index: true, element: <Navigate to="/settings/account" /> },
+          { path: "account", element: <AccountDetails /> },
+        ],
       },
     ],
   },

--- a/app/routes/settings/SettingsLayout.tsx
+++ b/app/routes/settings/SettingsLayout.tsx
@@ -2,10 +2,12 @@
 /* SPDX-License-Identifier: MIT */
 
 import { Box } from "@mui/material";
-import { useOutlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 export default function SettingsLayout(): JSX.Element {
-  const outlet = useOutlet();
-
-  return <Box>{outlet}</Box>;
+  return (
+    <Box>
+      <Outlet />
+    </Box>
+  );
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,7 +3,7 @@
 
 import react from "@vitejs/plugin-react";
 import envars from "envars";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 // Load environment variables for the target environment
 envars.config();
@@ -14,6 +14,7 @@ envars.config();
   "APP_ENV",
   "APP_NAME",
   "APP_ORIGIN",
+  "APP_HOSTNAME",
   "GOOGLE_CLOUD_PROJECT",
   "FIREBASE_APP_ID",
   "FIREBASE_API_KEY",
@@ -29,8 +30,6 @@ export default defineConfig({
   cacheDir: `../.cache/vite-app`,
 
   build: {
-    outDir: "./dist",
-    emptyOutDir: true,
     rollupOptions: {
       output: {
         manualChunks: {
@@ -58,6 +57,12 @@ export default defineConfig({
         target: process.env.API_ORIGIN,
         changeOrigin: true,
       },
+    },
+  },
+
+  test: {
+    cache: {
+      dir: "../.cache/vitest-app",
     },
   },
 });

--- a/edge/index.ts
+++ b/edge/index.ts
@@ -20,6 +20,12 @@ app.get("/echo", ({ json, req }) => {
   });
 });
 
+app.all("/__/*", ({ req }) => {
+  const url = new URL(req.url);
+  const origin = "https://caia-app.web.app";
+  return fetch(`${origin}${url.pathname}${url.search}`, req);
+});
+
 // Rewrite HTTP requests starting with "/api/"
 // to the Star Wars API as an example
 app.use("/api/*", ({ req }) => {
@@ -37,7 +43,17 @@ const fallback = serveStatic({ path: "/index.html", manifest });
 app.use("*", async (ctx, next) => {
   const url = new URL(ctx.req.url);
 
-  const isKnownRoute = ["", "/", "/privacy", "/terms"].includes(url.pathname);
+  // Alternatively, import the list of routes from the `app` package
+  const isKnownRoute = [
+    "",
+    "/",
+    "/dashboard",
+    "/settings",
+    "/login",
+    "/signup",
+    "/privacy",
+    "/terms",
+  ].includes(url.pathname);
 
   // Serve index.html for known URL routes
   if (isKnownRoute) {
@@ -48,7 +64,7 @@ app.use("*", async (ctx, next) => {
   const res = await asset(ctx, next);
 
   // Serve index.html for unknown URL routes with 404 status code
-  if (res?.status === 404 && !getMimeType(url.pathname)) {
+  if (!res && !getMimeType(url.pathname)) {
     const res = await fallback(ctx, next);
 
     if (res) {

--- a/edge/vite.config.ts
+++ b/edge/vite.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
   // Unit testing configuration
   // https://vitest.dev/config/
   test: {
+    cache: {
+      dir: "../.cache/vitest-edge",
+    },
     deps: {
       registerNodeLoader: true,
       external: ["__STATIC_CONTENT_MANIFEST"],

--- a/env/.local.env
+++ b/env/.local.env
@@ -6,6 +6,7 @@
 # Web application settings
 APP_ENV=local
 APP_NAME=React App
+APP_HOSTNAME=localhost
 APP_ORIGIN=http://localhost:5173
 API_ORIGIN=https://api-mcfytwakla-uc.a.run.app
 

--- a/env/.prod.env
+++ b/env/.prod.env
@@ -6,6 +6,7 @@
 # Web application settings
 APP_ENV=prod
 APP_NAME=React App
+APP_HOSTNAME=example.com
 APP_ORIGIN=https://example.com
 API_ORIGIN=https://example.com
 

--- a/env/.test.env
+++ b/env/.test.env
@@ -6,6 +6,7 @@
 # Web application settings
 APP_ENV=test
 APP_NAME=React App
+APP_HOSTNAME=test.example.com
 APP_ORIGIN=https://test.example.com
 API_ORIGIN=https://test.example.com
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "yarn@4.0.0-rc.39",
   "type": "module",
   "workspaces": [
+    "api",
     "app",
     "edge",
     "scripts"

--- a/scripts/wrangler.js
+++ b/scripts/wrangler.js
@@ -16,10 +16,6 @@ const [args, envName = "test"] = getArgs();
 // Load environment variables from `env/*.env` file(s)
 envars.config({ cwd: path.resolve(__dirname, "../env"), env: envName });
 
-if (!$.env.APP_HOSTNAME && $.env.APP_ORIGIN) {
-  $.env.APP_HOSTNAME = new URL($.env.APP_ORIGIN).hostname;
-}
-
 // Load Wrangler CLI configuration file
 let config = toml.parse(await fs.readFile("./wrangler.toml", "utf-8"));
 
@@ -55,9 +51,9 @@ const p = execa(
     "--experimental-json-config",
     "-c",
     "./dist/wrangler.json",
+    envName === "prod" ? undefined : `--env=${envName}`,
     ...args,
-    ...[envName === "prod" ? [] : [`--env=${envName}`]],
-  ],
+  ].filter(Boolean),
   {
     stdio: secret && $.env[secret] ? ["pipe", "inherit", "inherit"] : "inherit",
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "references": [
+    { "path": "./api" },
     { "path": "./app" },
     { "path": "./edge" },
     { "path": "./scripts" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.20.12":
+"@babel/core@npm:^7.20.12, @babel/core@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/core@npm:7.21.0"
   dependencies:
@@ -2506,10 +2506,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"api@workspace:api":
+  version: 0.0.0-use.local
+  resolution: "api@workspace:api"
+  dependencies:
+    "@cloudflare/workers-types": "npm:^4.20230221.0"
+    dotenv: "npm:^16.0.3"
+    hono: "npm:^3.0.1"
+    toml: "npm:^3.0.0"
+    typescript: "npm:^4.9.5"
+    vite: "npm:^4.1.4"
+    vitest: "npm:^0.28.5"
+  languageName: unknown
+  linkType: soft
+
 "app@workspace:app":
   version: 0.0.0-use.local
   resolution: "app@workspace:app"
   dependencies:
+    "@babel/core": "npm:^7.21.0"
     "@babel/runtime": "npm:^7.21.0"
     "@emotion/babel-plugin": "npm:^11.10.6"
     "@emotion/react": "npm:^11.10.6"
@@ -3320,7 +3335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0":
+"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
   checksum: abce82d99b45e2ebbd42625a78cadbfafe03072c15e6538b6a3a7ed204b6e091c0de929dd09231edc61f78afbdcd5b8a2f21b9e933e8ab27d75bee865a0e58c9


### PR DESCRIPTION
- Add the minimal boilerplate for implementing an API endpoint powered by [Hono.js](https://hono.dev/) (see `/api`)
- Add more details to `README.md` files across the project
- Fix fallback endpoint serving `index.html` for unknown URLs at CDN edge (see `./edge`)