### PR TITLE
docs: update Bun commands to use --filter instead of --cwd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,12 @@ bun test:edge                  # Test edge (shortcut)
 
 # Other
 bun lint                       # Lint all code
-bun --cwd db push              # Apply DB schema changes
+bun --filter @repo/db push     # Apply DB schema changes
 
 # Database
-bun --cwd db generate          # Generate migrations
-bun --cwd db studio            # Open DB GUI
-bun --cwd db seed              # Seed sample data
+bun --filter @repo/db generate # Generate migrations
+bun --filter @repo/db studio   # Open DB GUI
+bun --filter @repo/db seed     # Seed sample data
 
 # Deployment
 bun wrangler deploy --env=production

--- a/README.md
+++ b/README.md
@@ -29,19 +29,20 @@ Be sure to join our [Discord channel](https://discord.gg/2nKEnKq) for assistance
 
 This starter kit uses a thoughtfully organized monorepo structure that promotes code reuse and maintainability:
 
-- [`app/`](./app) — React frontend with Vite, TanStack Router, and Tailwind CSS
-- [`api/`](./api) — tRPC API server powered by Hono framework
-- [`edge/`](./edge) — Cloudflare Workers entry point for edge deployment
-- [`core/`](./core) — Shared TypeScript types, utilities, and WebSocket communication
+- [`apps/web/`](./apps/web) — React frontend with Vite, TanStack Router, and Tailwind CSS
+- [`apps/api/`](./apps/api) — tRPC API server powered by Hono framework
+- [`apps/edge/`](./apps/edge) — Cloudflare Workers entry point for edge deployment
+- [`packages/core/`](./packages/core) — Shared TypeScript types and utilities
+- [`packages/ws-protocol/`](./packages/ws-protocol) — WebSocket protocol template with type-safe messaging
 - [`db/`](./db) — Database schemas, migrations, and seed data
 - [`docs/`](./docs) — VitePress documentation site
 - [`infra/`](./infra) — Terraform infrastructure configurations for multi-environment deployment
 - [`scripts/`](./scripts) — Build automation and development tools
-- [`app/scripts/`](./app/scripts) — ShadCN UI component management utilities
+- [`apps/web/scripts/`](./apps/web/scripts) — ShadCN UI component management utilities
 
 **Why Monorepo?** This structure enables seamless code sharing between frontend and backend, ensures type consistency across your entire stack, and simplifies dependency management. When you update a type definition, both client and server stay in sync automatically.
 
-**Deployment Flexibility:** The API is deployed to Cloudflare Workers (via `edge/`) for global edge computing, ensuring optimal performance worldwide.
+**Deployment Flexibility:** The API is deployed to Cloudflare Workers (via `apps/edge/`) for global edge computing, ensuring optimal performance worldwide.
 
 ## Perfect For
 
@@ -119,13 +120,13 @@ Open two terminals and run these commands:
 **Terminal 1 - Frontend:**
 
 ```bash
-bun --cwd app dev
+bun --filter @repo/web dev
 ```
 
 **Terminal 2 - Backend:**
 
 ```bash
-bun --cwd edge build --watch
+bun --filter @repo/edge build --watch
 bun wrangler dev
 ```
 
@@ -133,8 +134,8 @@ bun wrangler dev
 
 ```bash
 # Apply database schema and migrations
-bun --cwd db migrate
-bun --cwd db seed  # Optional: add sample data
+bun --filter @repo/db migrate
+bun --filter @repo/db seed  # Optional: add sample data
 ```
 
 Open <http://localhost:5173> to see your app running. The backend API will be available at the port shown by `wrangler dev` (typically 8787).
@@ -155,8 +156,8 @@ bun wrangler secret put OPENAI_API_KEY --env=production
 
 ```bash
 # Build all packages
-bun --cwd app build
-bun --cwd edge build
+bun --filter @repo/web build
+bun --filter @repo/edge build
 
 # Deploy to Cloudflare Workers
 bun wrangler deploy --env=production

--- a/apps/api/start.ts
+++ b/apps/api/start.ts
@@ -15,7 +15,7 @@
  * @example
  * Start the development server:
  * ```bash
- * bun --cwd api dev
+ * bun --filter @repo/api dev
  * ```
  *
  * SPDX-FileCopyrightText: 2014-present Kriasoft

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -150,22 +150,22 @@ Domain-specific components that combine UI primitives:
 
 ```bash
 # Start development server
-bun --cwd app dev
+bun --filter @repo/web dev
 
 # Run type checking
-bun --cwd app typecheck
+bun --filter @repo/web typecheck
 
 # Run tests
-bun --cwd app test
+bun --filter @repo/web test
 
 # Run tests in watch mode
-bun --cwd app test --watch
+bun --filter @repo/web test --watch
 
 # Lint code
-bun --cwd app lint
+bun --filter @repo/web lint
 
 # Build for production
-bun --cwd app build
+bun --filter @repo/web build
 ```
 
 ### Component Development
@@ -341,10 +341,10 @@ export const Route = createFileRoute("/dashboard")({
 
 ```bash
 # Analyze bundle size
-bun --cwd app build && bun --cwd app analyze
+bun --filter @repo/web build && bun --filter @repo/web analyze
 
 # Check for unused dependencies
-bun --cwd app depcheck
+bun --filter @repo/web depcheck
 ```
 
 ## Testing Strategy
@@ -372,7 +372,7 @@ Test complete user flows including routing and API calls.
 ### Production Build
 
 ```bash
-bun --cwd app build
+bun --filter @repo/web build
 ```
 
 This creates an optimized build in the `dist/` directory with:

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -26,11 +26,11 @@
 
 ## Common Commands
 
-- `bun --cwd db generate --name <name>` - Generate migrations
-- `bun --cwd db migrate` - Apply migrations to database
-- `bun --cwd db studio` - Open Drizzle Studio
-- `bun --cwd db push` - Push schema to database
-- `bun --cwd db seed` - Seed database with test data
+- `bun --filter @repo/db generate --name <name>` - Generate migrations
+- `bun --filter @repo/db migrate` - Apply migrations to database
+- `bun --filter @repo/db studio` - Open Drizzle Studio
+- `bun --filter @repo/db push` - Push schema to database
+- `bun --filter @repo/db seed` - Seed database with test data
 
 ## Conventions
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -400,8 +400,8 @@ betterAuth({
 3. Generate and apply migrations:
 
 ```bash
-bun --cwd db generate --name add-custom-fields
-bun --cwd db migrate # or, bun --cwd db push
+bun --filter @repo/db generate --name add-custom-fields
+bun --filter @repo/db migrate # or, bun --filter @repo/db push
 ```
 
 ## Database Seeding
@@ -419,11 +419,11 @@ Seed scripts are located in `db/seeds/` and organized by entity type:
 
 ```bash
 # Seed development database
-bun --cwd db seed
+bun --filter @repo/db seed
 
 # Seed specific environments
-bun --cwd db seed:staging
-bun --cwd db seed:prod
+bun --filter @repo/db seed:staging
+bun --filter @repo/db seed:prod
 ```
 
 ### Creating Custom Seeds

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,10 +87,13 @@ Once you're set up, here's what you're working with:
 
 ```bash
 my-app/
-├── app/          # React 19 frontend (where the magic happens)
-├── api/          # tRPC backend (type-safe goodness)
-├── core/         # Shared modules and utilities
-├── edge/         # Cloudflare Workers entry point
+├── apps/
+│   ├── web/      # React 19 frontend (where the magic happens)
+│   ├── api/      # tRPC backend (type-safe goodness)
+│   └── edge/     # Cloudflare Workers entry point
+├── packages/
+│   ├── core/     # Shared modules and utilities
+│   └── ws-protocol/ # WebSocket protocol template
 ├── db/           # Database schemas and migrations
 ├── infra/        # Terraform infrastructure configuration
 ├── docs/         # Documentation (you are here!)
@@ -127,15 +130,15 @@ The `bun dev` command runs multiple processes concurrently:
 Open your browser and check out:
 
 - **Frontend**: `http://localhost:5173` — Your React app with TanStack Router
-- **Database GUI**: Run `bun --cwd db studio` to explore your database
+- **Database GUI**: Run `bun --filter @repo/db studio` to explore your database
 
 ### 3. Make It Yours
 
 Time to customize:
 
-1. **Update branding** → Edit `app/index.html` with your app's title
-2. **Homepage content** → Modify `app/routes/index.tsx`
-3. **API endpoints** → Check out `api/routers/` for tRPC routes
+1. **Update branding** → Edit `apps/web/index.html` with your app's title
+2. **Homepage content** → Modify `apps/web/routes/index.tsx`
+3. **API endpoints** → Check out `apps/api/routers/` for tRPC routes
 4. **Data models** → Explore `db/schema/` for database structure
 
 ## Database Setup
@@ -144,17 +147,17 @@ The template uses Cloudflare D1 (SQLite) with Drizzle ORM. To set up your databa
 
 ```bash
 # Generate the initial schema
-bun --cwd db generate
+bun --filter @repo/db generate
 
 # Apply migrations to your local database
-bun --cwd db push
+bun --filter @repo/db push
 
 # (Optional) Seed with sample data
-bun --cwd db seed
+bun --filter @repo/db seed
 ```
 
 ::: tip Database GUI
-Want to explore your data visually? Run `bun --cwd db studio` to open Drizzle Studio in your browser.
+Want to explore your data visually? Run `bun --filter @repo/db studio` to open Drizzle Studio in your browser.
 :::
 
 ## Authentication
@@ -163,8 +166,8 @@ Better Auth is pre-configured but needs your touch:
 
 1. **Create environment file** → Create `.env.local` (excluded from Git)
 2. **Add OAuth credentials** → Google, GitHub, etc.
-3. **Client setup** → Check `app/lib/auth.ts`
-4. **Server config** → See `api/auth.ts`
+3. **Client setup** → Check `apps/web/lib/auth.ts`
+4. **Server config** → See `apps/api/lib/auth.ts`
 
 ::: details Example .env.local
 
@@ -197,15 +200,15 @@ bun lint
 ```
 
 ::: info Type Checking
-TypeScript checking happens automatically in your editor. For CI/CD, run `bun --cwd api build` to verify types.
+TypeScript checking happens automatically in your editor. For CI/CD, run `bun --filter @repo/api build` to verify types.
 :::
 
 ### 💡 Hot Tips for Development
 
 - **API Types**: After modifying tRPC routes, types auto-generate — no manual sync needed
-- **Database Changes**: Edit `db/schema/`, then run `bun --cwd db generate` and `push`
-- **Component Library**: ShadCN UI components are ready to use — check `app/components/ui`
-- **State Management**: Global state lives in `app/lib/store.ts` using Jotai
+- **Database Changes**: Edit `db/schema/`, then run `bun --filter @repo/db generate` and `push`
+- **Component Library**: ShadCN UI components are ready to use — check `apps/web/components/ui`
+- **State Management**: Global state lives in `apps/web/lib/store.ts` using Jotai
 
 ## Deploy to Production
 
@@ -245,14 +248,14 @@ All API calls go through `/api/trpc` — the client handles this automatically. 
 :::
 
 ::: info Build Errors
-If TypeScript complains, try `bun --cwd api build` first. This regenerates type definitions.
+If TypeScript complains, try `bun --filter @repo/api build` first. This regenerates type definitions.
 :::
 
 ## Next Steps
 
 Now that you're up and running:
 
-1. Browse the [example components](https://github.com/kriasoft/react-starter-kit/tree/main/app/components) for inspiration
+1. Browse the [example components](https://github.com/kriasoft/react-starter-kit/tree/main/apps/web/components) for inspiration
 2. Check out the [deployment guide](/deployment) for advanced Cloudflare setup
 3. Join our [Discord community](https://discord.gg/2nKEnKq) for help and updates
 


### PR DESCRIPTION
## Summary

Updates all Bun commands throughout the documentation to use the `--filter` flag instead of `--cwd` for better workspace management and developer experience.

## Changes

- Replace `bun --cwd <dir>` with `bun --filter @repo/<package>` in all documentation
- Update commands in README.md, CLAUDE.md files, and docs/ directory
- Fix inline code documentation in apps/api/start.ts

## Benefits

The `--filter` approach provides several advantages:
- **Workspace-aware**: Automatically handles dependencies between packages
- **Location-independent**: Works from any directory in the monorepo
- **Cleaner syntax**: Uses package names instead of directory paths
- **Future-proof**: Package names remain stable even if directory structure changes

## Examples

Before:
```bash
bun --cwd db migrate
bun --cwd apps/web build
```

After:
```bash
bun --filter @repo/db migrate
bun --filter @repo/web build
```

This change improves the developer experience and aligns with modern monorepo best practices.