### PR TITLE
chore: add Dependabot configurationin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration for automated dependency updates
+# Creates weekly PRs with all dependency updates grouped together
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        # Allow security updates to be created separately
+        applies-to: version-updates


### PR DESCRIPTION
## What's changed

- Added `.github/dependabot.yml` for automated dependency updates
- Configured weekly updates (Mondays 4 AM UTC) with all dependencies grouped
- Added "dependencies" label and "deps" commit prefix for better organization
- Security updates handled separately for critical fixes

## Why

Keeps dependencies current with minimal maintenance overhead. Weekly cadence balances staying up-to-date with avoiding PR fatigue. Grouped updates reduce noise while allowing security patches to bypass grouping.

## Testing

Dependabot will create its first PR on the next Monday after merge, with up to 5 open PRs allowed.