### PR TITLE
feat(db): replace UUID with prefixed CUID2 IDs

### DIFF
--- a/apps/api/lib/auth.ts
+++ b/apps/api/lib/auth.ts
@@ -1,6 +1,6 @@
 import { passkey } from "@better-auth/passkey";
 import { stripe } from "@better-auth/stripe";
-import { schema as Db } from "@repo/db";
+import { schema as Db, generateAuthId, type AuthModel } from "@repo/db";
 import { betterAuth } from "better-auth";
 import type { DB } from "better-auth/adapters/drizzle";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -101,7 +101,7 @@ function stripePlugin(db: DB, env: AuthEnv) {
  * Key behaviors:
  * - Uses custom 'identity' table instead of default 'account' model for OAuth accounts
  * - Allows users to create up to 5 organizations with 'owner' role as creator
- * - Delegates ID generation to database (schema defaults to gen_random_uuid)
+ * - Generates prefixed CUID2 IDs at application level (e.g. usr_..., ses_...)
  * - Supports anonymous authentication alongside email/password and Google OAuth
  *
  * @param db Drizzle database instance - must include all required auth tables (user, session, identity, organization, member, invitation, verification)
@@ -201,7 +201,7 @@ export function createAuth(
 
     advanced: {
       database: {
-        generateId: false,
+        generateId: ({ model }) => generateAuthId(model as AuthModel),
       },
     },
 

--- a/bun.lock
+++ b/bun.lock
@@ -179,6 +179,9 @@
     "db": {
       "name": "@repo/db",
       "version": "0.0.0",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^3.3.0",
+      },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
         "@types/bun": "^1.3.9",
@@ -642,6 +645,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@paralleldrive/cuid2": ["@paralleldrive/cuid2@3.3.0", "", { "dependencies": { "@noble/hashes": "^2.0.1", "bignumber.js": "^9.3.1", "error-causes": "^3.0.2" }, "bin": { "cuid2": "bin/cuid2.js" } }, "sha512-OqiFvSOF0dBSesELYY2CAMa4YINvlLpvKOz/rv6NeZEqiyttlHgv98Juwv4Ch+GrEV7IZ8jfI2VcEoYUjXXCjw=="],
 
     "@peculiar/asn1-android": ["@peculiar/asn1-android@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ=="],
 
@@ -1804,6 +1809,8 @@
     "envars": ["envars@1.1.1", "", { "dependencies": { "@google-cloud/secret-manager": "^5.6.0", "dotenv": "^16.4.7", "dotenv-expand": "^12.0.1", "esbuild": "^0.24.2", "module-from-string": "^3.3.1", "parent-module": "^3.1.0", "read-pkg-up": "^11.0.0" } }, "sha512-dCRNfwscMiMUyh+CA8ifYRHefzxaUjCs3JEax932rKNMP2cE61Ue7Ifm1lnqVK0RfI40hX7XfJuzZjchdBYzvw=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "error-causes": ["error-causes@3.0.2", "", {}, "sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -1,7 +1,7 @@
 ## Schema Conventions
 
 - Drizzle `casing: "snake_case"` — use camelCase in TypeScript, columns map to snake_case in DB.
-- All primary keys: `text().primaryKey().default(sql`gen_random_uuid()`)`.
+- All primary keys: `text().primaryKey().$defaultFn(() => generateAuthId(...))` — application-generated prefixed CUID2 IDs (e.g. `usr_ght4k2jxm7pqbv01`). See `db/schema/id.ts` for prefix map.
 - Timestamps: `timestamp({ withTimezone: true, mode: "date" })`. Every table has `createdAt` (`.defaultNow().notNull()`) and `updatedAt` (`.defaultNow().$onUpdate(() => new Date()).notNull()`).
 - `identity` table = Better Auth's `account` table, renamed via `account.modelName: "identity"` in auth config.
 - `member.role` and `invitation.status` are free `text`, not pgEnum — avoids fragile coupling with Better Auth's values.

--- a/db/README.md
+++ b/db/README.md
@@ -90,16 +90,6 @@ import { organization, member } from "@/db/schema/organization";
 - Wrong environment: confirm `ENVIRONMENT`/`NODE_ENV` matches the target and the corresponding `.env.*` file exists.
 - Drift/conflicts: run `bun --filter @repo/db check`; regenerate migrations if schema and migrations diverge.
 
-## UUID v7
+## ID Generation
 
-The schema uses `gen_random_uuid()` by default for maximum compatibility. For time-ordered UUIDs (better index locality), replace with:
-
-- **PostgreSQL 18+**: `uuidv7()` (native)
-- **Earlier versions**: `uuid_generate_v7()` (requires [pg_uuidv7](https://github.com/fboulnois/pg_uuidv7) extension
-
-```typescript
-// Example: enable UUID v7 in schema
-id: text()
-  .primaryKey()
-  .default(sql`uuidv7()`);
-```
+All primary keys use application-generated prefixed CUID2 IDs (e.g. `usr_ght4k2jxm7pqbv01`). IDs are generated at the application level via `$defaultFn()` — no database-level defaults. See `db/schema/id.ts` for the prefix map and `docs/specs/prefixed-ids.md` for design rationale.

--- a/db/migrations/0000_init.sql
+++ b/db/migrations/0000_init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE "invitation" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"email" text NOT NULL,
 	"inviter_id" text NOT NULL,
 	"organization_id" text NOT NULL,
@@ -14,7 +14,7 @@ CREATE TABLE "invitation" (
 );
 --> statement-breakpoint
 CREATE TABLE "passkey" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"name" text,
 	"public_key" text NOT NULL,
 	"user_id" text NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE "passkey" (
 );
 --> statement-breakpoint
 CREATE TABLE "member" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
 	"organization_id" text NOT NULL,
 	"role" text NOT NULL,
@@ -43,7 +43,7 @@ CREATE TABLE "member" (
 );
 --> statement-breakpoint
 CREATE TABLE "organization" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"name" text NOT NULL,
 	"slug" text NOT NULL,
 	"logo" text,
@@ -55,7 +55,7 @@ CREATE TABLE "organization" (
 );
 --> statement-breakpoint
 CREATE TABLE "identity" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"account_id" text NOT NULL,
 	"provider_id" text NOT NULL,
 	"user_id" text NOT NULL,
@@ -72,7 +72,7 @@ CREATE TABLE "identity" (
 );
 --> statement-breakpoint
 CREATE TABLE "session" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"expires_at" timestamp with time zone NOT NULL,
 	"token" text NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
@@ -85,7 +85,7 @@ CREATE TABLE "session" (
 );
 --> statement-breakpoint
 CREATE TABLE "subscription" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"plan" text NOT NULL,
 	"reference_id" text NOT NULL,
 	"stripe_customer_id" text,
@@ -108,7 +108,7 @@ CREATE TABLE "subscription" (
 );
 --> statement-breakpoint
 CREATE TABLE "user" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"name" text NOT NULL,
 	"email" text NOT NULL,
 	"email_verified" boolean DEFAULT false NOT NULL,
@@ -121,7 +121,7 @@ CREATE TABLE "user" (
 );
 --> statement-breakpoint
 CREATE TABLE "verification" (
-	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" text PRIMARY KEY NOT NULL,
 	"identifier" text NOT NULL,
 	"value" text NOT NULL,
 	"expires_at" timestamp with time zone NOT NULL,

--- a/db/migrations/meta/0000_snapshot.json
+++ b/db/migrations/meta/0000_snapshot.json
@@ -12,8 +12,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "email": {
           "name": "email",
@@ -166,8 +165,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "name": {
           "name": "name",
@@ -305,8 +303,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "user_id": {
           "name": "user_id",
@@ -413,8 +410,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "name": {
           "name": "name",
@@ -483,8 +479,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "account_id": {
           "name": "account_id",
@@ -609,8 +604,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "expires_at": {
           "name": "expires_at",
@@ -726,8 +720,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "plan": {
           "name": "plan",
@@ -895,8 +888,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "name": {
           "name": "name",
@@ -973,8 +965,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
+          "notNull": true
         },
         "identifier": {
           "name": "identifier",

--- a/db/package.json
+++ b/db/package.json
@@ -44,5 +44,8 @@
     "drizzle-kit": "^0.31.9",
     "drizzle-orm": "^0.45.1",
     "typescript": "~5.9.3"
+  },
+  "dependencies": {
+    "@paralleldrive/cuid2": "^3.3.0"
   }
 }

--- a/db/schema/id.ts
+++ b/db/schema/id.ts
@@ -1,0 +1,50 @@
+// Prefixed CUID2 ID generation for all database entities.
+// Format: {prefix}_{body} e.g. "usr_ght4k2jxm7pqbv01" (20 chars total)
+// See docs/specs/prefixed-ids.md for design rationale.
+
+import { init } from "@paralleldrive/cuid2";
+
+// Keys are Better Auth's internal model names (not table names).
+// "account" maps to the "identity" table via account.modelName config.
+const AUTH_PREFIX = {
+  user: "usr",
+  session: "ses",
+  account: "idn", // "identity" table — avoids confusion with user/billing account
+  verification: "vfy",
+  organization: "org",
+  member: "mem",
+  invitation: "inv",
+  passkey: "pky",
+  subscription: "sub",
+} as const;
+
+export type AuthModel = keyof typeof AUTH_PREFIX;
+
+const ID_LENGTH = 16;
+let _createId: (() => string) | null = null;
+
+function createId(): string {
+  if (!_createId) _createId = init({ length: ID_LENGTH });
+  return _createId();
+}
+
+/** Generate a prefixed ID for a Better Auth model (e.g. `"user"` → `"usr_..."`) */
+export function generateAuthId(model: AuthModel): string {
+  const prefix = AUTH_PREFIX[model];
+  if (!prefix) {
+    throw new Error(
+      `Unknown auth model "${String(model)}". Add it to AUTH_PREFIX in db/schema/id.ts`,
+    );
+  }
+  return `${prefix}_${createId()}`;
+}
+
+/** Generate a prefixed ID for non-auth tables (e.g. `generateId("upl")`) */
+export function generateId(prefix: string): string {
+  if (!/^[a-z]{3}$/.test(prefix)) {
+    throw new Error(
+      `ID prefix must be exactly 3 lowercase letters, got "${prefix}"`,
+    );
+  }
+  return `${prefix}_${createId()}`;
+}

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./id";
 export * from "./invitation";
 export * from "./organization";
 export * from "./passkey";

--- a/db/schema/invitation.ts
+++ b/db/schema/invitation.ts
@@ -1,7 +1,8 @@
 // Better Auth invitation system for organization invites
 
-import { relations, sql } from "drizzle-orm";
+import { relations } from "drizzle-orm";
 import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { generateAuthId } from "./id";
 import { organization } from "./organization";
 import { user } from "./user";
 
@@ -18,7 +19,7 @@ export const invitation = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("invitation")),
     email: text().notNull(),
     inviterId: text()
       .notNull()

--- a/db/schema/organization.ts
+++ b/db/schema/organization.ts
@@ -1,7 +1,8 @@
 // Multi-tenant organizations and memberships with role-based access control
 
-import { relations, sql } from "drizzle-orm";
+import { relations } from "drizzle-orm";
 import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { generateAuthId } from "./id";
 import { user } from "./user";
 
 /**
@@ -11,7 +12,7 @@ import { user } from "./user";
 export const organization = pgTable("organization", {
   id: text()
     .primaryKey()
-    .default(sql`gen_random_uuid()`),
+    .$defaultFn(() => generateAuthId("organization")),
   name: text().notNull(),
   slug: text().notNull().unique(),
   logo: text(),
@@ -45,7 +46,7 @@ export const member = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("member")),
     userId: text()
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),

--- a/db/schema/passkey.ts
+++ b/db/schema/passkey.ts
@@ -1,7 +1,6 @@
 // WebAuthn passkey credentials for Better Auth
 // @see https://www.better-auth.com/docs/plugins/passkey
 
-import { sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -10,6 +9,7 @@ import {
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
+import { generateAuthId } from "./id";
 import { user } from "./user";
 
 /**
@@ -25,7 +25,7 @@ export const passkey = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("passkey")),
     name: text(),
     publicKey: text().notNull(),
     userId: text()

--- a/db/schema/subscription.ts
+++ b/db/schema/subscription.ts
@@ -2,7 +2,6 @@
 // referenceId is polymorphic: points to user.id or organization.id depending
 // on whether the subscription is personal or org-level billing.
 
-import { sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -11,13 +10,14 @@ import {
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
+import { generateAuthId } from "./id";
 
 export const subscription = pgTable(
   "subscription",
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("subscription")),
     plan: text().notNull(),
     referenceId: text().notNull(),
     stripeCustomerId: text(),

--- a/db/schema/user.ts
+++ b/db/schema/user.ts
@@ -14,7 +14,7 @@
  * @see https://www.better-auth.com/docs/adapters/drizzle
  */
 
-import { relations, sql } from "drizzle-orm";
+import { relations } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -23,6 +23,7 @@ import {
   timestamp,
   unique,
 } from "drizzle-orm/pg-core";
+import { generateAuthId } from "./id";
 
 /**
  * User accounts table.
@@ -31,7 +32,7 @@ import {
 export const user = pgTable("user", {
   id: text()
     .primaryKey()
-    .default(sql`gen_random_uuid()`),
+    .$defaultFn(() => generateAuthId("user")),
   name: text().notNull(),
   email: text().notNull().unique(),
   emailVerified: boolean().default(false).notNull(),
@@ -59,7 +60,7 @@ export const session = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("session")),
     expiresAt: timestamp({ withTimezone: true, mode: "date" }).notNull(),
     token: text().notNull().unique(),
     createdAt: timestamp({ withTimezone: true, mode: "date" })
@@ -94,7 +95,7 @@ export const identity = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("account")),
     accountId: text().notNull(),
     providerId: text().notNull(),
     userId: text()
@@ -136,7 +137,7 @@ export const verification = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateAuthId("verification")),
     identifier: text().notNull(),
     value: text().notNull(),
     expiresAt: timestamp({ withTimezone: true, mode: "date" }).notNull(),

--- a/docs/recipes/teams.md
+++ b/docs/recipes/teams.md
@@ -7,8 +7,9 @@ Teams let you create subgroups within organizations. This recipe shows how to en
 Create `db/schema/team.ts`:
 
 ```typescript
-import { relations, sql } from "drizzle-orm";
+import { relations } from "drizzle-orm";
 import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { generateId } from "./id";
 import { organization } from "./organization";
 import { user } from "./user";
 
@@ -17,7 +18,7 @@ export const team = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateId("tea")),
     name: text().notNull(),
     organizationId: text()
       .notNull()
@@ -38,7 +39,7 @@ export const teamMember = pgTable(
   {
     id: text()
       .primaryKey()
-      .default(sql`gen_random_uuid()`),
+      .$defaultFn(() => generateId("tmb")),
     teamId: text()
       .notNull()
       .references(() => team.id, { onDelete: "cascade" }),

--- a/docs/specs/prefixed-ids.md
+++ b/docs/specs/prefixed-ids.md
@@ -1,0 +1,69 @@
+# Prefixed CUID2 Database IDs
+
+All database primary keys use application-generated, prefixed [CUID2](https://github.com/paralleldrive/cuid2) identifiers: `usr_ght4k2jxm7pqbv01`. The prefix encodes entity type, improving debuggability across logs, URLs, and support conversations. Same pattern as Stripe (`cus_`, `sub_`), Clerk (`user_`, `org_`).
+
+IDs are opaque strings — clients must not parse or decode them.
+
+## Format
+
+```text
+{prefix}_{body}        Example: usr_ght4k2jxm7pqbv01
+ └──3──┘ └─16─┘        20 chars total
+```
+
+- **Prefix:** 3-char lowercase entity type
+- **Body:** 16-char CUID2 (alphanumeric, starts with letter)
+
+## Prefix Map
+
+Defined in `db/schema/id.ts`. Keys are Better Auth model names (not table names).
+
+| Model          | Prefix | Notes                                                   |
+| -------------- | ------ | ------------------------------------------------------- |
+| `user`         | `usr`  |                                                         |
+| `session`      | `ses`  |                                                         |
+| `account`      | `idn`  | Maps to `identity` table via `account.modelName` config |
+| `verification` | `vfy`  |                                                         |
+| `organization` | `org`  |                                                         |
+| `member`       | `mem`  |                                                         |
+| `invitation`   | `inv`  |                                                         |
+| `passkey`      | `pky`  |                                                         |
+| `subscription` | `sub`  |                                                         |
+
+## API
+
+```ts
+import { generateAuthId, generateId } from "@repo/db";
+
+// Auth tables — type-checked against the prefix map
+generateAuthId("user"); // "usr_ght4k2jxm7pqbv01"
+
+// Non-auth tables — any 3-letter prefix
+generateId("upl"); // "upl_m8xk3jvqp2wnba09"
+```
+
+Throws on unknown auth models or invalid prefixes. The CUID2 generator is lazy-initialized (no module-level side effects — safe for Workers isolates).
+
+## Integration Points
+
+**Better Auth** — `apps/api/lib/auth.ts`:
+
+```ts
+advanced: {
+  database: {
+    generateId: ({ model }) => generateAuthId(model as AuthModel),
+  },
+},
+```
+
+**Drizzle schema** — `db/schema/*.ts` use `.$defaultFn()` instead of `gen_random_uuid()`:
+
+```ts
+id: text().primaryKey().$defaultFn(() => generateAuthId("user")),
+```
+
+## Adding a New Model
+
+1. Add the prefix to `AUTH_PREFIX` in `db/schema/id.ts`
+2. Use `.$defaultFn(() => generateAuthId("modelName"))` in the schema
+3. Re-generate migrations: `bun db:generate`


### PR DESCRIPTION
### Summary

Replace `gen_random_uuid()` database defaults with application-generated **prefixed CUID2** identifiers across all auth tables. The 3-char prefix encodes entity type for instant recognition in logs, URLs, and support tickets — same pattern as [Stripe](https://dev.to/stripe/designing-apis-for-humans-object-ids-3o5a) (`cus_`, `sub_`), [Clerk](https://clerk.com/blog/generating-sortable-stripe-like-ids-with-segment-ksuids) (`user_`, `org_`).

```
 usr_ght4k2jxm7pqbv01
└─3─┘└──────16──────┘  20 chars total
```

### Why prefixed IDs

- **Debuggability** — seeing `usr_...` in a Sentry trace or log line immediately tells you the entity type without a database lookup
- **Type safety at boundaries** — a function receiving an `org_` ID can reject a `usr_` ID before hitting the DB
- **Double-click selection** — underscore-joined strings select as one word in terminals and editors (unlike hyphenated UUIDs)

### Why CUID2 over UUID v4

- Shorter (16-char body vs 32 hex digits), alphanumeric-only (no dashes, URL-safe)
- Multi-source entropy + SHA3 hash — no timestamp or host leakage ([paralleldrive/cuid2](https://github.com/paralleldrive/cuid2))
- Lazy-initialized generator — no module-level side effects, safe for Cloudflare Workers isolates

### Changes

- **`db/schema/id.ts`** (new) — `generateAuthId(model)` and `generateId(prefix)` helpers with prefix map, lazy CUID2 init
- **`db/schema/*.ts`** — replace `.default(sql'gen_random_uuid()')` with `.$defaultFn(() => generateAuthId(...))`
- **`apps/api/lib/auth.ts`** — wire `generateAuthId` into Better Auth's `advanced.database.generateId` hook
- **`db/migrations/0000_init.sql`** — regenerated (removes DB-level `DEFAULT` clauses)
- **`db/package.json`** — add `@paralleldrive/cuid2` dependency
- **`docs/`** — update schema docs, add `docs/specs/prefixed-ids.md` spec

### Usage

```ts
import { generateAuthId, generateId } from "@repo/db";

generateAuthId("user");        // "usr_ght4k2jxm7pqbv01"
generateAuthId("session");     // "ses_m8xk3jvqp2wnba09"
generateId("upl");             // "upl_p4qr7nxlk2vmtc06"
```

### Prefix map

| Model          | Prefix | Table        |
|----------------|--------|--------------|
| `user`         | `usr`  | `user`       |
| `session`      | `ses`  | `session`    |
| `account`      | `idn`  | `identity`   |
| `verification` | `vfy`  | `verification` |
| `organization` | `org`  | `organization` |
| `member`       | `mem`  | `member`     |
| `invitation`   | `inv`  | `invitation` |
| `passkey`      | `pky`  | `passkey`    |
| `subscription` | `sub`  | `subscription` |

### Migration

Existing `text()` columns accept both UUID and prefixed-CUID2 values — no data migration required. New inserts get the new format; legacy rows keep UUIDs.

### Test plan

- [x] `bun typecheck` passes
- [x] `bun test` passes
- [x] `bun db:generate` produces no diff (migration already regenerated)
- [x] Sign up flow creates users with `usr_` prefixed IDs
- [x] Better Auth session/identity/verification records use correct prefixes