### PR TITLE
feat(app): add light/dark/system theme switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 /.cache
 /*/.swc/
 .eslintcache
+tmp/
 
 # Testing
 /coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ bun ui:add <component>         # Add shadcn/ui component to packages/ui
 - API worker has `nodejs_compat` enabled; web and app workers do NOT.
 - Web worker routes: `/api/*` → API worker, app routes → App worker, static → assets.
 - Service bindings connect workers internally (no public cross-worker URLs).
-- Database, auth, routing, and tRPC conventions are in subdirectory `AGENTS.md` files.
+- Per-workspace conventions live in subdirectory `AGENTS.md` files: `apps/api/` (tRPC, auth), `apps/app/` (routing, theming), `db/` (schema), `packages/ui/` (components).
 
 ## Design Philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Monorepo Structure
 
-- `apps/web/` — Edge worker; routes traffic to app/api workers via service bindings
+- `apps/web/` — Astro marketing site, served by an edge worker that also routes traffic to the app/api workers via service bindings
 - `apps/app/` — Main SPA (React, TanStack Router file-based routing)
 - `apps/api/` — API server (Hono + tRPC + Better Auth)
 - `apps/email/` — React Email templates (built before API dev server starts)
@@ -36,11 +36,11 @@ bun ui:add <component>         # Add shadcn/ui component to packages/ui
 
 ## Architecture
 
-- Three workers: web (edge router), app (SPA assets), api (Hono server).
+- Three workers: web (marketing site + edge router), app (SPA assets), api (Hono server).
 - API worker has `nodejs_compat` enabled; web and app workers do NOT.
 - Web worker routes: `/api/*` → API worker, app routes → App worker, static → assets.
 - Service bindings connect workers internally (no public cross-worker URLs).
-- Per-workspace conventions live in subdirectory `AGENTS.md` files: `apps/api/` (tRPC, auth), `apps/app/` (routing, theming), `db/` (schema), `packages/ui/` (components).
+- Per-workspace conventions live in subdirectory `AGENTS.md` files: `apps/api/`, `apps/app/`, `db/`, `packages/ui/`.
 
 ## Design Philosophy
 

--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -28,6 +28,15 @@ Client-side SPA — no SSR. All rendering happens in the browser.
 - Route context: `Route.useSearch()` for search params, `Route.useRouteContext()` for route data.
 - Jotai store available for cross-route UI state (modals, sidebar).
 
+## Theming
+
+- `<html>` is written by exactly two things: the inline script in `index.html` (pre-paint) and `<ThemeSync />` in `lib/theme.tsx` (everything after). Read via `useTheme()`; never toggle the class from a component.
+- `preference` is what the user chose (`light` | `dark` | `system`); `theme` is the resolved value (`light` | `dark`) and is derived, never stored.
+- Mounting never writes to storage — the default stays absent until the user picks. An absent key and a stored `"system"` behave identically, so don't build logic on the difference.
+- That script duplicates the resolution logic on purpose — it runs before the bundle, so dark-mode users don't get a white flash. Its storage key and JSON encoding must match `theme.tsx`; `theme.test.tsx` guards the pair.
+- `systemThemeAtom` is lazy so its first read happens during render. Seeding it with a value would repaint a frame after the inline script already got it right — `theme.test.tsx` guards this.
+- `--theme-color` in `styles/globals.css` is the source for `<meta name="theme-color">`. `index.html` (both values) and `public/site.manifest` (light) must repeat it, since they load before any stylesheet. Change all three together — no test catches this drift.
+
 ## Error Handling
 
 - `AppErrorBoundary` (root) shows generic error UI. `AuthErrorBoundary` (protected routes) catches 401/UNAUTHORIZED and shows sign-in recovery UI; 403 falls through to generic handler.

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -14,57 +14,35 @@
     <meta property="og:url" content="" />
     <meta property="og:image" content="" />
     <meta name="theme-color" content="#fafafa" />
+
+    <!--
+      Apply the saved theme before first paint, otherwise a dark-mode user sees
+      a white flash while the bundle loads. Mirrors apps/app/lib/theme.tsx: same
+      storage key, same JSON encoding (Jotai's atomWithStorage).
+
+      Both hexes repeat --theme-color from globals.css – light on the meta tag
+      above, dark here. Stylesheets aren't parsed yet, so this script can't read
+      them; ThemeSync takes over once React mounts.
+    -->
     <script>
       (() => {
-        const STORAGE_KEY = "app-theme-preference";
-        const LEGACY_STORAGE_KEY = "app-theme";
-        const LIGHT_THEME_COLOR = "#fafafa";
-        const DARK_THEME_COLOR = "#0f0f0f";
-
-        function parsePreference(value) {
-          if (value === "light" || value === "dark" || value === "system") {
-            return value;
-          }
-          return null;
-        }
-
-        function getSystemTheme() {
-          return window.matchMedia?.("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light";
-        }
-
-        let preference = "system";
-
+        let preference;
         try {
-          const stored = parsePreference(
-            window.localStorage.getItem(STORAGE_KEY),
-          );
-          if (stored) {
-            preference = stored;
-          } else {
-            const legacy = parsePreference(
-              window.localStorage.getItem(LEGACY_STORAGE_KEY),
-            );
-            if (legacy === "light" || legacy === "dark") {
-              preference = legacy;
-            }
-          }
+          preference = JSON.parse(localStorage.getItem("theme"));
         } catch {
-          preference = "system";
+          // Storage unavailable or corrupt – fall back to the OS setting.
         }
-
-        const theme = preference === "system" ? getSystemTheme() : preference;
-        const root = document.documentElement;
-        root.dataset.themeColorLight = LIGHT_THEME_COLOR;
-        root.dataset.themeColorDark = DARK_THEME_COLOR;
-        root.classList.toggle("dark", theme === "dark");
-
-        const meta = document.querySelector('meta[name="theme-color"]');
-        meta?.setAttribute(
-          "content",
-          theme === "dark" ? DARK_THEME_COLOR : LIGHT_THEME_COLOR,
-        );
+        const dark =
+          preference === "dark" ||
+          (preference !== "light" &&
+            matchMedia("(prefers-color-scheme: dark)").matches);
+        document.documentElement.classList.toggle("dark", dark);
+        document.documentElement.style.colorScheme = dark ? "dark" : "light";
+        if (dark) {
+          document
+            .querySelector('meta[name="theme-color"]')
+            .setAttribute("content", "#0f0f0f");
+        }
       })();
     </script>
 

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -16,7 +16,6 @@
     <meta name="theme-color" content="#fafafa" />
     <script>
       (() => {
-        // Keep this bootstrap logic in sync with runtime theme resolution in lib/theme.tsx.
         const STORAGE_KEY = "app-theme-preference";
         const LEGACY_STORAGE_KEY = "app-theme";
         const LIGHT_THEME_COLOR = "#fafafa";
@@ -56,7 +55,10 @@
         }
 
         const theme = preference === "system" ? getSystemTheme() : preference;
-        document.documentElement.classList.toggle("dark", theme === "dark");
+        const root = document.documentElement;
+        root.dataset.themeColorLight = LIGHT_THEME_COLOR;
+        root.dataset.themeColorDark = DARK_THEME_COLOR;
+        root.classList.toggle("dark", theme === "dark");
 
         const meta = document.querySelector('meta[name="theme-color"]');
         meta?.setAttribute(

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -14,6 +14,57 @@
     <meta property="og:url" content="" />
     <meta property="og:image" content="" />
     <meta name="theme-color" content="#fafafa" />
+    <script>
+      (() => {
+        // Keep this bootstrap logic in sync with runtime theme resolution in lib/theme.tsx.
+        const STORAGE_KEY = "app-theme-preference";
+        const LEGACY_STORAGE_KEY = "app-theme";
+        const LIGHT_THEME_COLOR = "#fafafa";
+        const DARK_THEME_COLOR = "#0f0f0f";
+
+        function parsePreference(value) {
+          if (value === "light" || value === "dark" || value === "system") {
+            return value;
+          }
+          return null;
+        }
+
+        function getSystemTheme() {
+          return window.matchMedia?.("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        }
+
+        let preference = "system";
+
+        try {
+          const stored = parsePreference(
+            window.localStorage.getItem(STORAGE_KEY),
+          );
+          if (stored) {
+            preference = stored;
+          } else {
+            const legacy = parsePreference(
+              window.localStorage.getItem(LEGACY_STORAGE_KEY),
+            );
+            if (legacy === "light" || legacy === "dark") {
+              preference = legacy;
+            }
+          }
+        } catch {
+          preference = "system";
+        }
+
+        const theme = preference === "system" ? getSystemTheme() : preference;
+        document.documentElement.classList.toggle("dark", theme === "dark");
+
+        const meta = document.querySelector('meta[name="theme-color"]');
+        meta?.setAttribute(
+          "content",
+          theme === "dark" ? DARK_THEME_COLOR : LIGHT_THEME_COLOR,
+        );
+      })();
+    </script>
 
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/logo192.png" />

--- a/apps/app/index.tsx
+++ b/apps/app/index.tsx
@@ -6,7 +6,8 @@ import { createRoot } from "react-dom/client";
 import { NotFound } from "./components/not-found";
 import { queryClient } from "./lib/query";
 import { routeTree } from "./lib/routeTree.gen";
-import { ThemeProvider } from "./lib/theme";
+import { StoreProvider } from "./lib/store";
+import { ThemeSync } from "./lib/theme";
 import "./styles/globals.css";
 
 const router = createRouter({
@@ -21,17 +22,18 @@ const root = createRoot(container!);
 
 root.render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
+    <StoreProvider>
+      <ThemeSync />
+      <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
-      </ThemeProvider>
-      {import.meta.env.DEV && (
-        <ReactQueryDevtools
-          initialIsOpen={false}
-          buttonPosition="bottom-right"
-        />
-      )}
-    </QueryClientProvider>
+        {import.meta.env.DEV && (
+          <ReactQueryDevtools
+            initialIsOpen={false}
+            buttonPosition="bottom-right"
+          />
+        )}
+      </QueryClientProvider>
+    </StoreProvider>
   </StrictMode>,
 );
 

--- a/apps/app/index.tsx
+++ b/apps/app/index.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import { NotFound } from "./components/not-found";
 import { queryClient } from "./lib/query";
 import { routeTree } from "./lib/routeTree.gen";
+import { ThemeProvider } from "./lib/theme";
 import "./styles/globals.css";
 
 const router = createRouter({
@@ -21,7 +22,9 @@ const root = createRoot(container!);
 root.render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ThemeProvider>
+        <RouterProvider router={router} />
+      </ThemeProvider>
       {import.meta.env.DEV && (
         <ReactQueryDevtools
           initialIsOpen={false}

--- a/apps/app/lib/theme.test.tsx
+++ b/apps/app/lib/theme.test.tsx
@@ -84,6 +84,8 @@ describe("ThemeProvider", () => {
 
     window.localStorage.clear();
     document.documentElement.classList.remove("dark");
+    document.documentElement.dataset.themeColorLight = "#fafafa";
+    document.documentElement.dataset.themeColorDark = "#0f0f0f";
 
     const existingMeta = document.querySelector('meta[name="theme-color"]');
     if (!existingMeta) {
@@ -112,6 +114,9 @@ describe("ThemeProvider", () => {
       writable: true,
       value: originalLocalStorage,
     });
+
+    delete document.documentElement.dataset.themeColorLight;
+    delete document.documentElement.dataset.themeColorDark;
 
     vi.restoreAllMocks();
   });

--- a/apps/app/lib/theme.test.tsx
+++ b/apps/app/lib/theme.test.tsx
@@ -1,0 +1,251 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider, useTheme } from "./theme";
+
+function ThemeProbe() {
+  const { theme, setTheme, toggleTheme } = useTheme();
+
+  return (
+    <>
+      <div data-testid="theme-value">{theme}</div>
+      <button onClick={() => setTheme("dark")} type="button">
+        set-dark
+      </button>
+      <button onClick={() => setTheme("light")} type="button">
+        set-light
+      </button>
+      <button onClick={toggleTheme} type="button">
+        toggle-theme
+      </button>
+    </>
+  );
+}
+
+describe("ThemeProvider", () => {
+  const storage = new Map<string, string>();
+  let originalMatchMedia: typeof window.matchMedia | undefined;
+  let originalLocalStorage: Storage;
+
+  const localStorageMock: Storage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: (index: number) => {
+      const keys = Array.from(storage.keys());
+      return keys[index] ?? null;
+    },
+    get length() {
+      return storage.size;
+    },
+  };
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    originalLocalStorage = window.localStorage;
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: localStorageMock,
+    });
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+  });
+
+  afterEach(() => {
+    cleanup();
+
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: originalLocalStorage,
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it("uses persisted localStorage theme on first render", () => {
+    window.localStorage.setItem("app-theme", "dark");
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("falls back to system preference when no theme is persisted", () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("writes updates to localStorage and keeps DOM class in sync", () => {
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "set-dark" }));
+    expect(window.localStorage.getItem("app-theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "set-light" }));
+    expect(window.localStorage.getItem("app-theme")).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("reacts to theme updates from storage events", async () => {
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    const event = new Event("storage");
+    Object.defineProperty(event, "key", { value: "app-theme" });
+    Object.defineProperty(event, "newValue", { value: "dark" });
+    window.dispatchEvent(event);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+  });
+
+  it("falls back to system preference when storage key is cleared", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "set-light" }));
+    window.localStorage.removeItem("app-theme");
+
+    const event = new Event("storage");
+    Object.defineProperty(event, "key", { value: "app-theme" });
+    Object.defineProperty(event, "newValue", { value: null });
+    window.dispatchEvent(event);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+    });
+  });
+
+  it("recovers when storage read throws", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...localStorageMock,
+        getItem: () => {
+          throw new Error("read denied");
+        },
+      } as Storage,
+    });
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+  });
+
+  it("ignores storage write failures", () => {
+    const setItem = vi.fn(() => {
+      throw new Error("write denied");
+    });
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...localStorageMock,
+        setItem,
+      } as Storage,
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "set-dark" }));
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(setItem).toHaveBeenCalled();
+  });
+});

--- a/apps/app/lib/theme.test.tsx
+++ b/apps/app/lib/theme.test.tsx
@@ -98,7 +98,7 @@ describe("theme", () => {
 
     expect(screen.getByTestId("preference")).toHaveTextContent("system");
     expect(screen.getByTestId("theme")).toHaveTextContent("dark");
-    // Mounting has no storage side effects – the default is not written back.
+    // The default is never written back.
     expect(localStorage.getItem("theme")).toBeNull();
   });
 
@@ -211,10 +211,9 @@ describe("theme", () => {
   });
 
   it("shares its storage contract with the pre-paint bootstrap", () => {
-    // index.html resolves the theme before the bundle loads, and a mismatch is
-    // invisible in CI and to light-mode developers – it only shows up as a
-    // white flash for dark-mode users. The tests above pin theme.tsx to this
-    // same key and encoding, so together they hold the two files in step.
+    // A mismatch only shows as a white flash for dark-mode users, so nothing
+    // else catches it. The tests above pin theme.tsx to the same key and
+    // encoding, holding the two files in step.
     expect(indexHtml).toContain('localStorage.getItem("theme")');
     expect(indexHtml).toContain("JSON.parse");
     expect(indexHtml).toContain("(prefers-color-scheme: dark)");

--- a/apps/app/lib/theme.test.tsx
+++ b/apps/app/lib/theme.test.tsx
@@ -9,19 +9,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider, useTheme } from "./theme";
 
 function ThemeProbe() {
-  const { theme, setTheme, toggleTheme } = useTheme();
+  const { theme, preference, setPreference } = useTheme();
 
   return (
     <>
-      <div data-testid="theme-value">{theme}</div>
-      <button onClick={() => setTheme("dark")} type="button">
-        set-dark
-      </button>
-      <button onClick={() => setTheme("light")} type="button">
+      <div data-testid="resolved-theme">{theme}</div>
+      <div data-testid="preference">{preference}</div>
+      <button onClick={() => setPreference("light")} type="button">
         set-light
       </button>
-      <button onClick={toggleTheme} type="button">
-        toggle-theme
+      <button onClick={() => setPreference("dark")} type="button">
+        set-dark
+      </button>
+      <button onClick={() => setPreference("system")} type="button">
+        set-system
       </button>
     </>
   );
@@ -31,6 +32,19 @@ describe("ThemeProvider", () => {
   const storage = new Map<string, string>();
   let originalMatchMedia: typeof window.matchMedia | undefined;
   let originalLocalStorage: Storage;
+
+  function createMediaQueryList(matches: boolean): MediaQueryList {
+    return {
+      matches,
+      media: "(prefers-color-scheme: dark)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+  }
 
   const localStorageMock: Storage = {
     getItem: (key: string) => storage.get(key) ?? null,
@@ -56,13 +70,30 @@ describe("ThemeProvider", () => {
     originalMatchMedia = window.matchMedia;
     originalLocalStorage = window.localStorage;
 
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue(createMediaQueryList(false)),
+    });
+
     Object.defineProperty(window, "localStorage", {
       configurable: true,
       writable: true,
       value: localStorageMock,
     });
+
     window.localStorage.clear();
     document.documentElement.classList.remove("dark");
+
+    const existingMeta = document.querySelector('meta[name="theme-color"]');
+    if (!existingMeta) {
+      const meta = document.createElement("meta");
+      meta.setAttribute("name", "theme-color");
+      meta.setAttribute("content", "#fafafa");
+      document.head.appendChild(meta);
+    } else {
+      existingMeta.setAttribute("content", "#fafafa");
+    }
   });
 
   afterEach(() => {
@@ -85,31 +116,11 @@ describe("ThemeProvider", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses persisted localStorage theme on first render", () => {
-    window.localStorage.setItem("app-theme", "dark");
-
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-  });
-
-  it("falls back to system preference when no theme is persisted", () => {
+  it("defaults to system preference when nothing is stored", () => {
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query === "(prefers-color-scheme: dark)",
-        media: query,
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
+      value: vi.fn().mockReturnValue(createMediaQueryList(true)),
     });
 
     render(
@@ -118,11 +129,44 @@ describe("ThemeProvider", () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+    expect(window.localStorage.getItem("app-theme-preference")).toBe("system");
   });
 
-  it("writes updates to localStorage and keeps DOM class in sync", () => {
+  it("uses persisted explicit preference", () => {
+    window.localStorage.setItem("app-theme-preference", "dark");
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("preference")).toHaveTextContent("dark");
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(
+      document
+        .querySelector('meta[name="theme-color"]')
+        ?.getAttribute("content"),
+    ).toBe("#0f0f0f");
+  });
+
+  it("migrates legacy app-theme values", () => {
+    window.localStorage.setItem("app-theme", "light");
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("preference")).toHaveTextContent("light");
+    expect(window.localStorage.getItem("app-theme-preference")).toBe("light");
+  });
+
+  it("updates preference and stores only the preference", () => {
     render(
       <ThemeProvider>
         <ThemeProbe />
@@ -130,15 +174,71 @@ describe("ThemeProvider", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "set-dark" }));
-    expect(window.localStorage.getItem("app-theme")).toBe("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(screen.getByTestId("preference")).toHaveTextContent("dark");
+    expect(window.localStorage.getItem("app-theme-preference")).toBe("dark");
+    expect(
+      document
+        .querySelector('meta[name="theme-color"]')
+        ?.getAttribute("content"),
+    ).toBe("#0f0f0f");
 
     fireEvent.click(screen.getByRole("button", { name: "set-light" }));
-    expect(window.localStorage.getItem("app-theme")).toBe("light");
-    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(screen.getByTestId("preference")).toHaveTextContent("light");
+    expect(window.localStorage.getItem("app-theme-preference")).toBe("light");
+    expect(
+      document
+        .querySelector('meta[name="theme-color"]')
+        ?.getAttribute("content"),
+    ).toBe("#fafafa");
+
+    fireEvent.click(screen.getByRole("button", { name: "set-system" }));
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
+    expect(window.localStorage.getItem("app-theme-preference")).toBe("system");
   });
 
-  it("reacts to theme updates from storage events", async () => {
+  it("reacts to OS theme changes while preference is system", async () => {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        ...createMediaQueryList(false),
+        addEventListener: (
+          _: string,
+          cb: (event: MediaQueryListEvent) => void,
+        ) => listeners.add(cb),
+        removeEventListener: (
+          _: string,
+          cb: (event: MediaQueryListEvent) => void,
+        ) => listeners.delete(cb),
+      }),
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("light");
+
+    listeners.forEach((listener) =>
+      listener({ matches: true } as MediaQueryListEvent),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(
+        document
+          .querySelector('meta[name="theme-color"]')
+          ?.getAttribute("content"),
+      ).toBe("#0f0f0f");
+    });
+  });
+
+  it("syncs preference across tabs via storage events", async () => {
     render(
       <ThemeProvider>
         <ThemeProbe />
@@ -146,28 +246,21 @@ describe("ThemeProvider", () => {
     );
 
     const event = new Event("storage");
-    Object.defineProperty(event, "key", { value: "app-theme" });
+    Object.defineProperty(event, "key", { value: "app-theme-preference" });
     Object.defineProperty(event, "newValue", { value: "dark" });
     window.dispatchEvent(event);
 
     await waitFor(() => {
-      expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(screen.getByTestId("preference")).toHaveTextContent("dark");
+      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
     });
   });
 
-  it("falls back to system preference when storage key is cleared", async () => {
+  it("does not overwrite preference with resolved system theme", () => {
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query === "(prefers-color-scheme: dark)",
-        media: query,
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
+      value: vi.fn().mockReturnValue(createMediaQueryList(true)),
     });
 
     render(
@@ -176,76 +269,8 @@ describe("ThemeProvider", () => {
       </ThemeProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "set-light" }));
-    window.localStorage.removeItem("app-theme");
-
-    const event = new Event("storage");
-    Object.defineProperty(event, "key", { value: "app-theme" });
-    Object.defineProperty(event, "newValue", { value: null });
-    window.dispatchEvent(event);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-    });
-  });
-
-  it("recovers when storage read throws", () => {
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      writable: true,
-      value: {
-        ...localStorageMock,
-        getItem: () => {
-          throw new Error("read denied");
-        },
-      } as Storage,
-    });
-
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query === "(prefers-color-scheme: dark)",
-        media: query,
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
-
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-  });
-
-  it("ignores storage write failures", () => {
-    const setItem = vi.fn(() => {
-      throw new Error("write denied");
-    });
-
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      writable: true,
-      value: {
-        ...localStorageMock,
-        setItem,
-      } as Storage,
-    });
-
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "set-dark" }));
-    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-    expect(setItem).toHaveBeenCalled();
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+    expect(window.localStorage.getItem("app-theme-preference")).toBe("system");
   });
 });

--- a/apps/app/lib/theme.test.tsx
+++ b/apps/app/lib/theme.test.tsx
@@ -1,281 +1,222 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ThemeProvider, useTheme } from "./theme";
+import indexHtml from "../index.html?raw";
+import { ThemeSync, useTheme } from "./theme";
+
+const root = document.documentElement;
+
+const mediaListeners = new Set<(event: MediaQueryListEvent) => void>();
+let systemPrefersDark = false;
+
+function setSystemPrefersDark(matches: boolean) {
+  systemPrefersDark = matches;
+  act(() => {
+    mediaListeners.forEach((listener) =>
+      listener({ matches } as MediaQueryListEvent),
+    );
+  });
+}
 
 function ThemeProbe() {
   const { theme, preference, setPreference } = useTheme();
 
   return (
     <>
-      <div data-testid="resolved-theme">{theme}</div>
-      <div data-testid="preference">{preference}</div>
-      <button onClick={() => setPreference("light")} type="button">
-        set-light
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="preference">{preference}</span>
+      <button type="button" onClick={() => setPreference("dark")}>
+        dark
       </button>
-      <button onClick={() => setPreference("dark")} type="button">
-        set-dark
-      </button>
-      <button onClick={() => setPreference("system")} type="button">
-        set-system
+      <button type="button" onClick={() => setPreference("system")}>
+        system
       </button>
     </>
   );
 }
 
-describe("ThemeProvider", () => {
-  const storage = new Map<string, string>();
-  let originalMatchMedia: typeof window.matchMedia | undefined;
-  let originalLocalStorage: Storage;
+/** A fresh Jotai store per render, so atoms re-read storage instead of reusing state. */
+function renderTheme() {
+  return render(
+    <Provider>
+      <ThemeSync />
+      <ThemeProbe />
+    </Provider>,
+  );
+}
 
-  function createMediaQueryList(matches: boolean): MediaQueryList {
-    return {
-      matches,
-      media: "(prefers-color-scheme: dark)",
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    } as unknown as MediaQueryList;
-  }
+function click(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
 
-  const localStorageMock: Storage = {
-    getItem: (key: string) => storage.get(key) ?? null,
-    setItem: (key: string, value: string) => {
-      storage.set(key, value);
-    },
-    removeItem: (key: string) => {
-      storage.delete(key);
-    },
-    clear: () => {
-      storage.clear();
-    },
-    key: (index: number) => {
-      const keys = Array.from(storage.keys());
-      return keys[index] ?? null;
-    },
-    get length() {
-      return storage.size;
-    },
-  };
+function syncFromOtherTab(value: string) {
+  fireEvent(
+    window,
+    new StorageEvent("storage", {
+      key: "theme",
+      newValue: JSON.stringify(value),
+      storageArea: localStorage,
+    }),
+  );
+}
 
+describe("theme", () => {
   beforeEach(() => {
-    originalMatchMedia = window.matchMedia;
-    originalLocalStorage = window.localStorage;
+    mediaListeners.clear();
+    systemPrefersDark = false;
+    localStorage.clear();
+    root.classList.remove("dark");
+    root.style.colorScheme = "";
 
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: vi.fn().mockReturnValue(createMediaQueryList(false)),
-    });
-
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      writable: true,
-      value: localStorageMock,
-    });
-
-    window.localStorage.clear();
-    document.documentElement.classList.remove("dark");
-    document.documentElement.dataset.themeColorLight = "#fafafa";
-    document.documentElement.dataset.themeColorDark = "#0f0f0f";
-
-    const existingMeta = document.querySelector('meta[name="theme-color"]');
-    if (!existingMeta) {
-      const meta = document.createElement("meta");
-      meta.setAttribute("name", "theme-color");
-      meta.setAttribute("content", "#fafafa");
-      document.head.appendChild(meta);
-    } else {
-      existingMeta.setAttribute("content", "#fafafa");
-    }
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        get matches() {
+          return systemPrefersDark;
+        },
+        addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+          mediaListeners.add(cb);
+        },
+        removeEventListener: (
+          _: string,
+          cb: (e: MediaQueryListEvent) => void,
+        ) => {
+          mediaListeners.delete(cb);
+        },
+      })),
+    );
   });
 
   afterEach(() => {
-    cleanup();
-
-    if (originalMatchMedia) {
-      Object.defineProperty(window, "matchMedia", {
-        configurable: true,
-        writable: true,
-        value: originalMatchMedia,
-      });
-    }
-
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      writable: true,
-      value: originalLocalStorage,
-    });
-
-    delete document.documentElement.dataset.themeColorLight;
-    delete document.documentElement.dataset.themeColorDark;
-
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("defaults to system preference when nothing is stored", () => {
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: vi.fn().mockReturnValue(createMediaQueryList(true)),
-    });
-
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
+  it("follows the OS setting by default", () => {
+    systemPrefersDark = true;
+    renderTheme();
 
     expect(screen.getByTestId("preference")).toHaveTextContent("system");
-    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
-    expect(window.localStorage.getItem("app-theme-preference")).toBe("system");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    // Mounting has no storage side effects – the default is not written back.
+    expect(localStorage.getItem("theme")).toBeNull();
   });
 
-  it("uses persisted explicit preference", () => {
-    window.localStorage.setItem("app-theme-preference", "dark");
+  it("does not undo what the bootstrap script already applied", () => {
+    // A system-dark user, with the class already on <html> as index.html leaves
+    // it. Resolving the OS setting a frame late here would repaint to light.
+    systemPrefersDark = true;
+    root.classList.add("dark");
 
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
+    const applied: (boolean | undefined)[] = [];
+    const toggle = root.classList.toggle.bind(root.classList);
+    vi.spyOn(root.classList, "toggle").mockImplementation((token, force) => {
+      applied.push(force);
+      return toggle(token, force);
+    });
+
+    renderTheme();
+
+    expect(applied).toEqual([true]);
+  });
+
+  it("restores a persisted preference over the OS setting", () => {
+    localStorage.setItem("theme", JSON.stringify("dark"));
+    renderTheme();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(root.classList.contains("dark")).toBe(true);
+    expect(root.style.colorScheme).toBe("dark");
+  });
+
+  it("ignores an unrecognized persisted value", () => {
+    localStorage.setItem("theme", JSON.stringify("sepia"));
+    renderTheme();
+
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
+  });
+
+  it("persists the preference and updates the document", () => {
+    renderTheme();
+
+    click("dark");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(root.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("theme")).toBe(JSON.stringify("dark"));
+
+    click("system");
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+    expect(root.classList.contains("dark")).toBe(false);
+    expect(root.style.colorScheme).toBe("light");
+  });
+
+  it("tracks OS changes while following the system", () => {
+    renderTheme();
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+
+    setSystemPrefersDark(true);
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(root.classList.contains("dark")).toBe(true);
+  });
+
+  it("ignores OS changes once a preference is set", () => {
+    renderTheme();
+
+    click("dark");
+    setSystemPrefersDark(false);
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+  });
+
+  it("syncs across tabs via storage events", () => {
+    renderTheme();
+
+    syncFromOtherTab("dark");
 
     expect(screen.getByTestId("preference")).toHaveTextContent("dark");
-    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-    expect(
-      document
-        .querySelector('meta[name="theme-color"]')
-        ?.getAttribute("content"),
-    ).toBe("#0f0f0f");
+    expect(root.classList.contains("dark")).toBe(true);
   });
 
-  it("migrates legacy app-theme values", () => {
-    window.localStorage.setItem("app-theme", "light");
+  it("ignores an unrecognized value from another tab", () => {
+    renderTheme();
 
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    expect(screen.getByTestId("preference")).toHaveTextContent("light");
-    expect(window.localStorage.getItem("app-theme-preference")).toBe("light");
-  });
-
-  it("updates preference and stores only the preference", () => {
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "set-dark" }));
-    expect(screen.getByTestId("preference")).toHaveTextContent("dark");
-    expect(window.localStorage.getItem("app-theme-preference")).toBe("dark");
-    expect(
-      document
-        .querySelector('meta[name="theme-color"]')
-        ?.getAttribute("content"),
-    ).toBe("#0f0f0f");
-
-    fireEvent.click(screen.getByRole("button", { name: "set-light" }));
-    expect(screen.getByTestId("preference")).toHaveTextContent("light");
-    expect(window.localStorage.getItem("app-theme-preference")).toBe("light");
-    expect(
-      document
-        .querySelector('meta[name="theme-color"]')
-        ?.getAttribute("content"),
-    ).toBe("#fafafa");
-
-    fireEvent.click(screen.getByRole("button", { name: "set-system" }));
-    expect(screen.getByTestId("preference")).toHaveTextContent("system");
-    expect(window.localStorage.getItem("app-theme-preference")).toBe("system");
-  });
-
-  it("reacts to OS theme changes while preference is system", async () => {
-    const listeners = new Set<(event: MediaQueryListEvent) => void>();
-
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: vi.fn().mockReturnValue({
-        ...createMediaQueryList(false),
-        addEventListener: (
-          _: string,
-          cb: (event: MediaQueryListEvent) => void,
-        ) => listeners.add(cb),
-        removeEventListener: (
-          _: string,
-          cb: (event: MediaQueryListEvent) => void,
-        ) => listeners.delete(cb),
-      }),
-    });
-
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("light");
-
-    listeners.forEach((listener) =>
-      listener({ matches: true } as MediaQueryListEvent),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
-      expect(document.documentElement.classList.contains("dark")).toBe(true);
-      expect(
-        document
-          .querySelector('meta[name="theme-color"]')
-          ?.getAttribute("content"),
-      ).toBe("#0f0f0f");
-    });
-  });
-
-  it("syncs preference across tabs via storage events", async () => {
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
-
-    const event = new Event("storage");
-    Object.defineProperty(event, "key", { value: "app-theme-preference" });
-    Object.defineProperty(event, "newValue", { value: "dark" });
-    window.dispatchEvent(event);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("preference")).toHaveTextContent("dark");
-      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
-    });
-  });
-
-  it("does not overwrite preference with resolved system theme", () => {
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: vi.fn().mockReturnValue(createMediaQueryList(true)),
-    });
-
-    render(
-      <ThemeProvider>
-        <ThemeProbe />
-      </ThemeProvider>,
-    );
+    // Sync to dark first, so falling back to "system" can't pass by doing nothing.
+    syncFromOtherTab("dark");
+    syncFromOtherTab("sepia");
 
     expect(screen.getByTestId("preference")).toHaveTextContent("system");
-    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
-    expect(window.localStorage.getItem("app-theme-preference")).toBe("system");
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+  });
+
+  it("still applies the theme when persistence fails", () => {
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    renderTheme();
+
+    click("dark");
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(root.classList.contains("dark")).toBe(true);
+  });
+
+  it("survives a browser that denies storage access", () => {
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    expect(() => renderTheme()).not.toThrow();
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
+  });
+
+  it("shares its storage contract with the pre-paint bootstrap", () => {
+    // index.html resolves the theme before the bundle loads, and a mismatch is
+    // invisible in CI and to light-mode developers – it only shows up as a
+    // white flash for dark-mode users. The tests above pin theme.tsx to this
+    // same key and encoding, so together they hold the two files in step.
+    expect(indexHtml).toContain('localStorage.getItem("theme")');
+    expect(indexHtml).toContain("JSON.parse");
+    expect(indexHtml).toContain("(prefers-color-scheme: dark)");
   });
 });

--- a/apps/app/lib/theme.tsx
+++ b/apps/app/lib/theme.tsx
@@ -1,10 +1,12 @@
 import {
   createContext,
   type ReactNode,
+  use,
+  useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
-  use,
 } from "react";
 
 type Theme = "light" | "dark";
@@ -22,9 +24,13 @@ const STORAGE_KEY = "app-theme";
 function getInitialTheme(): Theme {
   if (typeof window === "undefined") return "light";
 
-  const stored = window.localStorage.getItem(STORAGE_KEY);
-  if (stored === "light" || stored === "dark") {
-    return stored;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+  } catch {
+    // Continue with system preference fallback.
   }
 
   if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
@@ -37,7 +43,7 @@ function getInitialTheme(): Theme {
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const root = document.documentElement;
 
     if (theme === "dark") {
@@ -46,12 +52,33 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       root.classList.remove("dark");
     }
 
-    window.localStorage.setItem(STORAGE_KEY, theme);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // Ignore storage write failures (e.g., private browsing mode).
+    }
   }, [theme]);
 
-  const toggleTheme = () => {
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      if (event.newValue === "light" || event.newValue === "dark") {
+        setTheme(event.newValue);
+        return;
+      }
+
+      setTheme(getInitialTheme());
+    };
+
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  const toggleTheme = useCallback(() => {
     setTheme((prev) => (prev === "dark" ? "light" : "dark"));
-  };
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -59,7 +86,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setTheme,
       toggleTheme,
     }),
-    [theme, setTheme, toggleTheme],
+    [theme],
   );
 
   return <ThemeContext value={value}>{children}</ThemeContext>;

--- a/apps/app/lib/theme.tsx
+++ b/apps/app/lib/theme.tsx
@@ -1,189 +1,141 @@
-import {
-  createContext,
-  type ReactNode,
-  use,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from "react";
+import { atom, useAtom, useAtomValue } from "jotai";
+import { atomWithLazy, atomWithStorage, createJSONStorage } from "jotai/utils";
+import { useLayoutEffect } from "react";
 
-type Theme = "light" | "dark";
+export type Theme = "light" | "dark";
 export type ThemePreference = Theme | "system";
 
-interface ThemeContextValue {
-  theme: Theme;
-  preference: ThemePreference;
-  setPreference: (preference: ThemePreference) => void;
+/**
+ * Shared with the inline bootstrap script in `index.html`, which applies the
+ * theme before first paint. Keep the key and its JSON encoding in sync.
+ */
+const STORAGE_KEY = "theme";
+
+const COLOR_SCHEME_QUERY = "(prefers-color-scheme: dark)";
+
+const jsonStorage = createJSONStorage<ThemePreference>();
+
+function toPreference(
+  value: unknown,
+  fallback: ThemePreference,
+): ThemePreference {
+  return value === "light" || value === "dark" || value === "system"
+    ? value
+    : fallback;
 }
 
-const ThemeContext = createContext<ThemeContextValue | null>(null);
+/**
+ * Persisted preference, mirrored across tabs by `atomWithStorage`.
+ *
+ * The three overrides exist because anything can end up in `localStorage`:
+ * both read paths are validated (the storage-event path bypasses `getItem`),
+ * and both directions swallow failures. The read especially – `getOnInit` runs
+ * it while this module evaluates, so a browser that denies storage access would
+ * otherwise take down the bundle before anything renders.
+ */
+const themePreferenceAtom = atomWithStorage<ThemePreference>(
+  STORAGE_KEY,
+  "system",
+  {
+    ...jsonStorage,
+    getItem: (key, initialValue) => {
+      try {
+        return toPreference(
+          jsonStorage.getItem(key, initialValue),
+          initialValue,
+        );
+      } catch {
+        return initialValue;
+      }
+    },
+    setItem: (key, value) => {
+      try {
+        jsonStorage.setItem(key, value);
+      } catch {
+        // Persistence is best-effort; the choice still applies this session.
+      }
+    },
+    subscribe: (key, callback, initialValue) =>
+      jsonStorage.subscribe?.(
+        key,
+        (value) => callback(toPreference(value, initialValue)),
+        initialValue,
+      ),
+  },
+  { getOnInit: true },
+);
 
-const STORAGE_KEY = "app-theme-preference";
-const LEGACY_STORAGE_KEY = "app-theme";
-const FALLBACK_LIGHT_THEME_COLOR = "#fafafa";
-const FALLBACK_DARK_THEME_COLOR = "#0f0f0f";
+/**
+ * OS color scheme, kept current while any subscriber is mounted. Lazy so the
+ * first read happens during render – seeding it with a guess would repaint the
+ * document a frame after the bootstrap script already got it right.
+ */
+const systemThemeAtom = atomWithLazy<Theme>(() =>
+  window.matchMedia(COLOR_SCHEME_QUERY).matches ? "dark" : "light",
+);
 
-function getThemeColor(theme: Theme): string {
-  const rootDataset = document.documentElement.dataset;
-  const light = rootDataset.themeColorLight || FALLBACK_LIGHT_THEME_COLOR;
-  const dark = rootDataset.themeColorDark || FALLBACK_DARK_THEME_COLOR;
+systemThemeAtom.onMount = (set) => {
+  const media = window.matchMedia(COLOR_SCHEME_QUERY);
+  // Re-read: a change between the lazy init and this subscription is missed.
+  set(media.matches ? "dark" : "light");
 
-  return theme === "dark" ? dark : light;
-}
+  const onChange = (event: MediaQueryListEvent) => {
+    set(event.matches ? "dark" : "light");
+  };
 
-// Keep this runtime resolution in sync with the inline bootstrap script in index.html.
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
+};
 
-function getSystemTheme(): Theme {
-  if (typeof window === "undefined") return "light";
+const themeAtom = atom<Theme>((get) => {
+  const preference = get(themePreferenceAtom);
+  return preference === "system" ? get(systemThemeAtom) : preference;
+});
 
-  if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
-    return "dark";
-  }
+/**
+ * Keeps `<html>` in sync with the resolved theme: the `dark` class drives
+ * Tailwind's dark variant, `color-scheme` drives native UI (scrollbars, form
+ * controls), and `theme-color` drives mobile browser chrome.
+ *
+ * Mount near the root. The bootstrap script in `index.html` settles all three
+ * before first paint; this keeps them current afterwards, and catches an OS or
+ * cross-tab change that landed between that script and React starting.
+ */
+export function ThemeSync() {
+  const theme = useAtomValue(themeAtom);
 
-  return "light";
-}
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    root.style.colorScheme = theme;
 
-function parseThemePreference(value: string | null): ThemePreference | null {
-  if (value === "light" || value === "dark" || value === "system") {
-    return value;
-  }
+    // Derived from CSS rather than repeated here. `index.html` and
+    // `site.manifest` do have to repeat it – they load before any stylesheet –
+    // so `--theme-color` in `globals.css` is the value they must track.
+    const color = getComputedStyle(root)
+      .getPropertyValue("--theme-color")
+      .trim();
+
+    if (color) {
+      document
+        .querySelector('meta[name="theme-color"]')
+        ?.setAttribute("content", color);
+    }
+  }, [theme]);
 
   return null;
 }
 
-function getInitialPreference(): ThemePreference {
-  if (typeof window === "undefined") return "system";
-
-  try {
-    const storedPreference = parseThemePreference(
-      window.localStorage.getItem(STORAGE_KEY),
-    );
-    if (storedPreference) {
-      return storedPreference;
-    }
-
-    const legacyTheme = parseThemePreference(
-      window.localStorage.getItem(LEGACY_STORAGE_KEY),
-    );
-    if (legacyTheme === "light" || legacyTheme === "dark") {
-      return legacyTheme;
-    }
-  } catch {
-    return "system";
-  }
-
-  return "system";
-}
-
-function resolveTheme(preference: ThemePreference, systemTheme: Theme): Theme {
-  if (preference === "system") {
-    return systemTheme;
-  }
-
-  return preference;
-}
-
-function setThemeColorMeta(theme: Theme) {
-  const meta = document.querySelector('meta[name="theme-color"]');
-  if (!meta) return;
-  meta.setAttribute("content", getThemeColor(theme));
-}
-
-function applyThemeWithoutTransitions(theme: Theme) {
-  const root = document.documentElement;
-  const style = document.createElement("style");
-  style.textContent = "*{transition:none!important}";
-  document.head.appendChild(style);
-
-  if (theme === "dark") {
-    root.classList.add("dark");
-  } else {
-    root.classList.remove("dark");
-  }
-
-  setThemeColorMeta(theme);
-
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      style.remove();
-    });
-  });
-}
-
-export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [preference, setPreference] =
-    useState<ThemePreference>(getInitialPreference);
-  const [systemTheme, setSystemTheme] = useState<Theme>(getSystemTheme);
-  const theme = useMemo(
-    () => resolveTheme(preference, systemTheme),
-    [preference, systemTheme],
-  );
-
-  useLayoutEffect(() => {
-    applyThemeWithoutTransitions(theme);
-  }, [theme]);
-
-  useEffect(() => {
-    const media = window.matchMedia?.("(prefers-color-scheme: dark)");
-    if (!media) return;
-
-    const onChange = (event: MediaQueryListEvent) => {
-      setSystemTheme(event.matches ? "dark" : "light");
-    };
-
-    media.addEventListener("change", onChange);
-    return () => {
-      media.removeEventListener("change", onChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, preference);
-    } catch {
-      // Ignore storage write failures (e.g., private browsing mode).
-    }
-  }, [preference]);
-
-  useEffect(() => {
-    const onStorage = (event: StorageEvent) => {
-      if (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY) return;
-
-      if (event.key === STORAGE_KEY) {
-        const nextPreference = parseThemePreference(event.newValue) ?? "system";
-        setPreference(nextPreference);
-        return;
-      }
-
-      const legacyTheme = parseThemePreference(event.newValue);
-      if (legacyTheme === "light" || legacyTheme === "dark") {
-        setPreference(legacyTheme);
-      }
-    };
-
-    window.addEventListener("storage", onStorage);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-    };
-  }, []);
-
-  const value = useMemo(
-    () => ({
-      theme,
-      preference,
-      setPreference,
-    }),
-    [theme, preference],
-  );
-
-  return <ThemeContext value={value}>{children}</ThemeContext>;
-}
-
-export function useTheme() {
-  const ctx = use(ThemeContext);
-  if (!ctx) {
-    throw new Error("useTheme must be used within a ThemeProvider");
-  }
-  return ctx;
+/**
+ * The return type is written out to keep the atoms an implementation detail:
+ * Jotai's own setter also accepts updater functions and `RESET`, which are
+ * persistence mechanics callers shouldn't reach for.
+ */
+export function useTheme(): {
+  theme: Theme;
+  preference: ThemePreference;
+  setPreference: (preference: ThemePreference) => void;
+} {
+  const [preference, setPreference] = useAtom(themePreferenceAtom);
+  return { theme: useAtomValue(themeAtom), preference, setPreference };
 }

--- a/apps/app/lib/theme.tsx
+++ b/apps/app/lib/theme.tsx
@@ -1,0 +1,74 @@
+import {
+  createContext,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+  use,
+} from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = "app-theme";
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  }
+
+  return "light";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return <ThemeContext value={value}>{children}</ThemeContext>;
+}
+
+export function useTheme() {
+  const ctx = use(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return ctx;
+}

--- a/apps/app/lib/theme.tsx
+++ b/apps/app/lib/theme.tsx
@@ -2,7 +2,6 @@ import {
   createContext,
   type ReactNode,
   use,
-  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -10,28 +9,25 @@ import {
 } from "react";
 
 type Theme = "light" | "dark";
+export type ThemePreference = Theme | "system";
 
 interface ThemeContextValue {
   theme: Theme;
-  setTheme: (theme: Theme) => void;
-  toggleTheme: () => void;
+  preference: ThemePreference;
+  setPreference: (preference: ThemePreference) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-const STORAGE_KEY = "app-theme";
+const STORAGE_KEY = "app-theme-preference";
+const LEGACY_STORAGE_KEY = "app-theme";
+const LIGHT_THEME_COLOR = "#fafafa";
+const DARK_THEME_COLOR = "#0f0f0f";
 
-function getInitialTheme(): Theme {
+// Keep this runtime resolution in sync with the inline bootstrap script in index.html.
+
+function getSystemTheme(): Theme {
   if (typeof window === "undefined") return "light";
-
-  try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored === "light" || stored === "dark") {
-      return stored;
-    }
-  } catch {
-    // Continue with system preference fallback.
-  }
 
   if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
     return "dark";
@@ -40,34 +36,125 @@ function getInitialTheme(): Theme {
   return "light";
 }
 
+function parseThemePreference(value: string | null): ThemePreference | null {
+  if (value === "light" || value === "dark" || value === "system") {
+    return value;
+  }
+
+  return null;
+}
+
+function getInitialPreference(): ThemePreference {
+  if (typeof window === "undefined") return "system";
+
+  try {
+    const storedPreference = parseThemePreference(
+      window.localStorage.getItem(STORAGE_KEY),
+    );
+    if (storedPreference) {
+      return storedPreference;
+    }
+
+    const legacyTheme = parseThemePreference(
+      window.localStorage.getItem(LEGACY_STORAGE_KEY),
+    );
+    if (legacyTheme === "light" || legacyTheme === "dark") {
+      return legacyTheme;
+    }
+  } catch {
+    return "system";
+  }
+
+  return "system";
+}
+
+function resolveTheme(preference: ThemePreference, systemTheme: Theme): Theme {
+  if (preference === "system") {
+    return systemTheme;
+  }
+
+  return preference;
+}
+
+function setThemeColorMeta(theme: Theme) {
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (!meta) return;
+  meta.setAttribute(
+    "content",
+    theme === "dark" ? DARK_THEME_COLOR : LIGHT_THEME_COLOR,
+  );
+}
+
+function applyThemeWithoutTransitions(theme: Theme) {
+  const root = document.documentElement;
+  const style = document.createElement("style");
+  style.textContent = "*{transition:none!important}";
+  document.head.appendChild(style);
+
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+
+  setThemeColorMeta(theme);
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      style.remove();
+    });
+  });
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  const [preference, setPreference] =
+    useState<ThemePreference>(getInitialPreference);
+  const [systemTheme, setSystemTheme] = useState<Theme>(getSystemTheme);
+  const theme = useMemo(
+    () => resolveTheme(preference, systemTheme),
+    [preference, systemTheme],
+  );
 
   useLayoutEffect(() => {
-    const root = document.documentElement;
-
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
-
-    try {
-      window.localStorage.setItem(STORAGE_KEY, theme);
-    } catch {
-      // Ignore storage write failures (e.g., private browsing mode).
-    }
+    applyThemeWithoutTransitions(theme);
   }, [theme]);
 
   useEffect(() => {
+    const media = window.matchMedia?.("(prefers-color-scheme: dark)");
+    if (!media) return;
+
+    const onChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+
+    media.addEventListener("change", onChange);
+    return () => {
+      media.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, preference);
+    } catch {
+      // Ignore storage write failures (e.g., private browsing mode).
+    }
+  }, [preference]);
+
+  useEffect(() => {
     const onStorage = (event: StorageEvent) => {
-      if (event.key !== STORAGE_KEY) return;
-      if (event.newValue === "light" || event.newValue === "dark") {
-        setTheme(event.newValue);
+      if (event.key !== STORAGE_KEY && event.key !== LEGACY_STORAGE_KEY) return;
+
+      if (event.key === STORAGE_KEY) {
+        const nextPreference = parseThemePreference(event.newValue) ?? "system";
+        setPreference(nextPreference);
         return;
       }
 
-      setTheme(getInitialTheme());
+      const legacyTheme = parseThemePreference(event.newValue);
+      if (legacyTheme === "light" || legacyTheme === "dark") {
+        setPreference(legacyTheme);
+      }
     };
 
     window.addEventListener("storage", onStorage);
@@ -76,17 +163,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const toggleTheme = useCallback(() => {
-    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
-  }, []);
-
   const value = useMemo(
     () => ({
       theme,
-      setTheme,
-      toggleTheme,
+      preference,
+      setPreference,
     }),
-    [theme],
+    [theme, preference],
   );
 
   return <ThemeContext value={value}>{children}</ThemeContext>;

--- a/apps/app/lib/theme.tsx
+++ b/apps/app/lib/theme.tsx
@@ -21,8 +21,16 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 const STORAGE_KEY = "app-theme-preference";
 const LEGACY_STORAGE_KEY = "app-theme";
-const LIGHT_THEME_COLOR = "#fafafa";
-const DARK_THEME_COLOR = "#0f0f0f";
+const FALLBACK_LIGHT_THEME_COLOR = "#fafafa";
+const FALLBACK_DARK_THEME_COLOR = "#0f0f0f";
+
+function getThemeColor(theme: Theme): string {
+  const rootDataset = document.documentElement.dataset;
+  const light = rootDataset.themeColorLight || FALLBACK_LIGHT_THEME_COLOR;
+  const dark = rootDataset.themeColorDark || FALLBACK_DARK_THEME_COLOR;
+
+  return theme === "dark" ? dark : light;
+}
 
 // Keep this runtime resolution in sync with the inline bootstrap script in index.html.
 
@@ -79,10 +87,7 @@ function resolveTheme(preference: ThemePreference, systemTheme: Theme): Theme {
 function setThemeColorMeta(theme: Theme) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (!meta) return;
-  meta.setAttribute(
-    "content",
-    theme === "dark" ? DARK_THEME_COLOR : LIGHT_THEME_COLOR,
-  );
+  meta.setAttribute("content", getThemeColor(theme));
 }
 
 function applyThemeWithoutTransitions(theme: Theme) {

--- a/apps/app/routes/(app)/settings.tsx
+++ b/apps/app/routes/(app)/settings.tsx
@@ -11,11 +11,10 @@ import {
   CardTitle,
   Input,
   Label,
-  RadioGroup,
-  RadioGroupItem,
   Separator,
   Switch,
 } from "@repo/ui";
+import { useCallback, useId, useRef } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
   Bell,
@@ -32,22 +31,62 @@ export const Route = createFileRoute("/(app)/settings")({
   component: Settings,
 });
 
+const THEME_OPTIONS: Array<{
+  value: ThemePreference;
+  label: string;
+  icon: typeof Sun;
+}> = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+];
+
 function Settings() {
   const { preference, setPreference } = useTheme();
+  const themeOptionRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const themeLabelId = useId();
 
-  function handlePreferenceChange(value: ThemePreference) {
-    setPreference(value);
-  }
+  const setOptionRef = useCallback(
+    (index: number, el: HTMLButtonElement | null) => {
+      themeOptionRef.current[index] = el;
+    },
+    [],
+  );
 
-  const themeOptions: Array<{
-    value: ThemePreference;
-    label: string;
-    icon: typeof Sun;
-  }> = [
-    { value: "light", label: "Light", icon: Sun },
-    { value: "dark", label: "Dark", icon: Moon },
-    { value: "system", label: "System", icon: Monitor },
-  ];
+  const handleThemeKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const isNextKey = event.key === "ArrowRight" || event.key === "ArrowDown";
+      const isPrevKey = event.key === "ArrowLeft" || event.key === "ArrowUp";
+
+      if (
+        !isNextKey &&
+        !isPrevKey &&
+        event.key !== "Home" &&
+        event.key !== "End"
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+
+      let nextIndex = index;
+
+      if (isNextKey) {
+        nextIndex = (index + 1) % THEME_OPTIONS.length;
+      } else if (isPrevKey) {
+        nextIndex = (index - 1 + THEME_OPTIONS.length) % THEME_OPTIONS.length;
+      } else if (event.key === "Home") {
+        nextIndex = 0;
+      } else if (event.key === "End") {
+        nextIndex = THEME_OPTIONS.length - 1;
+      }
+
+      const nextOption = THEME_OPTIONS[nextIndex];
+      setPreference(nextOption.value);
+      themeOptionRef.current[nextIndex]?.focus();
+    },
+    [setPreference],
+  );
 
   return (
     <div className="p-6 space-y-6">
@@ -157,45 +196,44 @@ function Settings() {
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
-                <Label>Theme</Label>
+                <Label id={themeLabelId}>Theme</Label>
                 <p className="text-sm text-muted-foreground">
                   Choose light, dark, or follow your OS setting.
                 </p>
               </div>
-              <RadioGroup
-                value={preference}
-                onValueChange={(value) =>
-                  handlePreferenceChange(value as ThemePreference)
-                }
-                aria-label="Theme preference"
+              <div
+                role="radiogroup"
+                aria-labelledby={themeLabelId}
                 className="inline-flex items-center gap-1 rounded-lg border bg-muted p-1"
               >
-                {themeOptions.map((option) => {
+                {THEME_OPTIONS.map((option, index) => {
                   const Icon = option.icon;
                   const isSelected = preference === option.value;
 
                   return (
-                    <Label
+                    <button
                       key={option.value}
-                      htmlFor={`theme-${option.value}`}
+                      type="button"
+                      role="radio"
+                      ref={(el) => setOptionRef(index, el)}
+                      onClick={() => setPreference(option.value)}
+                      onKeyDown={(event) => handleThemeKeyDown(event, index)}
+                      tabIndex={isSelected ? 0 : -1}
                       className={[
-                        "inline-flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+                        "inline-flex size-11 cursor-pointer items-center justify-center rounded-md border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                         isSelected
                           ? "bg-background text-foreground shadow-sm"
-                          : "text-muted-foreground hover:text-foreground focus-within:text-foreground",
+                          : "text-muted-foreground hover:text-foreground",
                       ].join(" ")}
+                      title={option.label}
+                      aria-label={option.label}
+                      aria-checked={isSelected}
                     >
-                      <RadioGroupItem
-                        id={`theme-${option.value}`}
-                        value={option.value}
-                        aria-label={option.label}
-                        className="sr-only"
-                      />
                       <Icon className="h-4 w-4" />
-                    </Label>
+                    </button>
                   );
                 })}
-              </RadioGroup>
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/apps/app/routes/(app)/settings.tsx
+++ b/apps/app/routes/(app)/settings.tsx
@@ -15,12 +15,15 @@ import { Bell, CreditCard, Palette, Shield, User } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { useBillingQuery } from "@/lib/queries/billing";
 import { useSessionQuery } from "@/lib/queries/session";
+import { useTheme } from "@/lib/theme";
 
 export const Route = createFileRoute("/(app)/settings")({
   component: Settings,
 });
 
 function Settings() {
+  const { theme, setTheme } = useTheme();
+
   return (
     <div className="p-6 space-y-6">
       <div>
@@ -134,7 +137,13 @@ function Settings() {
                   Toggle dark mode theme
                 </p>
               </div>
-              <Switch id="dark-mode" />
+              <Switch
+                id="dark-mode"
+                checked={theme === "dark"}
+                onCheckedChange={(checked: boolean) =>
+                  setTheme(checked ? "dark" : "light")
+                }
+              />
             </div>
           </CardContent>
         </Card>

--- a/apps/app/routes/(app)/settings.tsx
+++ b/apps/app/routes/(app)/settings.tsx
@@ -1,3 +1,7 @@
+import { auth } from "@/lib/auth";
+import { useBillingQuery } from "@/lib/queries/billing";
+import { useSessionQuery } from "@/lib/queries/session";
+import { type ThemePreference, useTheme } from "@/lib/theme";
 import {
   Button,
   Card,
@@ -7,22 +11,43 @@ import {
   CardTitle,
   Input,
   Label,
+  RadioGroup,
+  RadioGroupItem,
   Separator,
   Switch,
 } from "@repo/ui";
 import { createFileRoute } from "@tanstack/react-router";
-import { Bell, CreditCard, Palette, Shield, User } from "lucide-react";
-import { auth } from "@/lib/auth";
-import { useBillingQuery } from "@/lib/queries/billing";
-import { useSessionQuery } from "@/lib/queries/session";
-import { useTheme } from "@/lib/theme";
+import {
+  Bell,
+  CreditCard,
+  Monitor,
+  Moon,
+  Palette,
+  Shield,
+  Sun,
+  User,
+} from "lucide-react";
 
 export const Route = createFileRoute("/(app)/settings")({
   component: Settings,
 });
 
 function Settings() {
-  const { theme, setTheme } = useTheme();
+  const { preference, setPreference } = useTheme();
+
+  function handlePreferenceChange(value: ThemePreference) {
+    setPreference(value);
+  }
+
+  const themeOptions: Array<{
+    value: ThemePreference;
+    label: string;
+    icon: typeof Sun;
+  }> = [
+    { value: "light", label: "Light", icon: Sun },
+    { value: "dark", label: "Dark", icon: Moon },
+    { value: "system", label: "System", icon: Monitor },
+  ];
 
   return (
     <div className="p-6 space-y-6">
@@ -132,18 +157,45 @@ function Settings() {
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
-                <Label htmlFor="dark-mode">Dark Mode</Label>
+                <Label>Theme</Label>
                 <p className="text-sm text-muted-foreground">
-                  Toggle dark mode theme
+                  Choose light, dark, or follow your OS setting.
                 </p>
               </div>
-              <Switch
-                id="dark-mode"
-                checked={theme === "dark"}
-                onCheckedChange={(checked: boolean) =>
-                  setTheme(checked ? "dark" : "light")
+              <RadioGroup
+                value={preference}
+                onValueChange={(value) =>
+                  handlePreferenceChange(value as ThemePreference)
                 }
-              />
+                aria-label="Theme preference"
+                className="inline-flex items-center gap-1 rounded-lg border bg-muted p-1"
+              >
+                {themeOptions.map((option) => {
+                  const Icon = option.icon;
+                  const isSelected = preference === option.value;
+
+                  return (
+                    <Label
+                      key={option.value}
+                      htmlFor={`theme-${option.value}`}
+                      className={[
+                        "inline-flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+                        isSelected
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground focus-within:text-foreground",
+                      ].join(" ")}
+                    >
+                      <RadioGroupItem
+                        id={`theme-${option.value}`}
+                        value={option.value}
+                        aria-label={option.label}
+                        className="sr-only"
+                      />
+                      <Icon className="h-4 w-4" />
+                    </Label>
+                  );
+                })}
+              </RadioGroup>
             </div>
           </CardContent>
         </Card>

--- a/apps/app/routes/(app)/settings.tsx
+++ b/apps/app/routes/(app)/settings.tsx
@@ -13,12 +13,15 @@ import {
   Label,
   Separator,
   Switch,
+  ToggleGroup,
+  ToggleGroupItem,
 } from "@repo/ui";
-import { useCallback, useId, useRef } from "react";
+import { useId } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
   Bell,
   CreditCard,
+  type LucideIcon,
   Monitor,
   Moon,
   Palette,
@@ -31,63 +34,7 @@ export const Route = createFileRoute("/(app)/settings")({
   component: Settings,
 });
 
-const THEME_OPTIONS: Array<{
-  value: ThemePreference;
-  label: string;
-  icon: typeof Sun;
-}> = [
-  { value: "light", label: "Light", icon: Sun },
-  { value: "dark", label: "Dark", icon: Moon },
-  { value: "system", label: "System", icon: Monitor },
-];
-
 function Settings() {
-  const { preference, setPreference } = useTheme();
-  const themeOptionRef = useRef<Array<HTMLButtonElement | null>>([]);
-  const themeLabelId = useId();
-
-  const setOptionRef = useCallback(
-    (index: number, el: HTMLButtonElement | null) => {
-      themeOptionRef.current[index] = el;
-    },
-    [],
-  );
-
-  const handleThemeKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-      const isNextKey = event.key === "ArrowRight" || event.key === "ArrowDown";
-      const isPrevKey = event.key === "ArrowLeft" || event.key === "ArrowUp";
-
-      if (
-        !isNextKey &&
-        !isPrevKey &&
-        event.key !== "Home" &&
-        event.key !== "End"
-      ) {
-        return;
-      }
-
-      event.preventDefault();
-
-      let nextIndex = index;
-
-      if (isNextKey) {
-        nextIndex = (index + 1) % THEME_OPTIONS.length;
-      } else if (isPrevKey) {
-        nextIndex = (index - 1 + THEME_OPTIONS.length) % THEME_OPTIONS.length;
-      } else if (event.key === "Home") {
-        nextIndex = 0;
-      } else if (event.key === "End") {
-        nextIndex = THEME_OPTIONS.length - 1;
-      }
-
-      const nextOption = THEME_OPTIONS[nextIndex];
-      setPreference(nextOption.value);
-      themeOptionRef.current[nextIndex]?.focus();
-    },
-    [setPreference],
-  );
-
   return (
     <div className="p-6 space-y-6">
       <div>
@@ -182,61 +129,8 @@ function Settings() {
           </CardContent>
         </Card>
 
-        {/* Appearance Settings */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Palette className="h-5 w-5" />
-              <CardTitle>Appearance</CardTitle>
-            </div>
-            <CardDescription>
-              Customize the look and feel of the application.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label id={themeLabelId}>Theme</Label>
-                <p className="text-sm text-muted-foreground">
-                  Choose light, dark, or follow your OS setting.
-                </p>
-              </div>
-              <div
-                role="radiogroup"
-                aria-labelledby={themeLabelId}
-                className="inline-flex items-center gap-1 rounded-lg border bg-muted p-1"
-              >
-                {THEME_OPTIONS.map((option, index) => {
-                  const Icon = option.icon;
-                  const isSelected = preference === option.value;
-
-                  return (
-                    <button
-                      key={option.value}
-                      type="button"
-                      role="radio"
-                      ref={(el) => setOptionRef(index, el)}
-                      onClick={() => setPreference(option.value)}
-                      onKeyDown={(event) => handleThemeKeyDown(event, index)}
-                      tabIndex={isSelected ? 0 : -1}
-                      className={[
-                        "inline-flex size-11 cursor-pointer items-center justify-center rounded-md border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                        isSelected
-                          ? "bg-background text-foreground shadow-sm"
-                          : "text-muted-foreground hover:text-foreground",
-                      ].join(" ")}
-                      title={option.label}
-                      aria-label={option.label}
-                      aria-checked={isSelected}
-                    >
-                      <Icon className="h-4 w-4" />
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        {/* Appearance */}
+        <AppearanceCard />
       </div>
     </div>
   );
@@ -332,6 +226,73 @@ function BillingCard() {
             </div>
           </div>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+const THEME_OPTIONS: Array<{
+  value: ThemePreference;
+  label: string;
+  icon: LucideIcon;
+}> = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+];
+
+function AppearanceCard() {
+  const { preference, setPreference } = useTheme();
+  const themeLabelId = useId();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Palette className="h-5 w-5" />
+          <CardTitle>Appearance</CardTitle>
+        </div>
+        <CardDescription>
+          Customize the look and feel of the application.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            {/* Not a <label>: it names a radiogroup, which htmlFor can't target. */}
+            <Label asChild>
+              <span id={themeLabelId}>Theme</span>
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              Choose light, dark, or follow your OS setting.
+            </p>
+          </div>
+          {/* type="single" gives radiogroup semantics and arrow-key navigation,
+              so there is no keyboard handling here. It also emits "" when the
+              active item is toggled off, hence the lookup below. */}
+          <ToggleGroup
+            type="single"
+            value={preference}
+            onValueChange={(value) => {
+              const option = THEME_OPTIONS.find((o) => o.value === value);
+              if (option) setPreference(option.value);
+            }}
+            aria-labelledby={themeLabelId}
+            className="rounded-lg border bg-muted p-1"
+          >
+            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <ToggleGroupItem
+                key={value}
+                value={value}
+                aria-label={label}
+                title={label}
+                className="size-9 data-[state=on]:bg-background data-[state=on]:shadow-sm"
+              >
+                <Icon className="h-4 w-4" />
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/app/routes/(app)/settings.tsx
+++ b/apps/app/routes/(app)/settings.tsx
@@ -69,7 +69,6 @@ function Settings() {
           </CardContent>
         </Card>
 
-        {/* Billing */}
         <BillingCard />
 
         {/* Notification Settings */}
@@ -129,7 +128,6 @@ function Settings() {
           </CardContent>
         </Card>
 
-        {/* Appearance */}
         <AppearanceCard />
       </div>
     </div>
@@ -267,9 +265,9 @@ function AppearanceCard() {
               Choose light, dark, or follow your OS setting.
             </p>
           </div>
-          {/* type="single" gives radiogroup semantics and arrow-key navigation,
-              so there is no keyboard handling here. It also emits "" when the
-              active item is toggled off, hence the lookup below. */}
+          {/* type="single" brings radiogroup semantics and arrow keys, so no
+              keyboard handling here. It emits "" when the active item is
+              toggled off, which the lookup below ignores. */}
           <ToggleGroup
             type="single"
             value={preference}

--- a/apps/app/styles/globals.css
+++ b/apps/app/styles/globals.css
@@ -44,6 +44,14 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /*
+   * Mobile browser chrome, published via <meta name="theme-color">.
+   * Hex rather than oklch(): browsers ignore a theme-color they can't parse.
+   * index.html (both themes) and public/site.manifest (light) repeat these
+   * values – they load before any stylesheet. Change them together.
+   */
+  --theme-color: #fafafa;
 }
 
 .dark {
@@ -79,6 +87,7 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --theme-color: #0f0f0f;
 }
 
 @layer base {

--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -1,1 +1,16 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+/**
+ * `window.localStorage` is undefined here – Node's own Web Storage global
+ * shadows happy-dom's and stays unset without `--localstorage-file`. Give it a
+ * real `Storage` so code under test persists the way it does in a browser.
+ */
+Object.defineProperty(window, "localStorage", {
+  configurable: true,
+  value: new window.Storage(),
+});
+
+// Testing Library only auto-cleans when Vitest globals are enabled.
+afterEach(cleanup);

--- a/bun.lock
+++ b/bun.lock
@@ -223,6 +223,8 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-toggle": "^1.1.18",
+        "@radix-ui/react-toggle-group": "^1.1.19",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.574.0",
@@ -754,6 +756,10 @@
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
     "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
+
+    "@radix-ui/react-toggle": ["@radix-ui/react-toggle@1.1.18", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-controllable-state": "1.2.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug=="],
+
+    "@radix-ui/react-toggle-group": ["@radix-ui/react-toggle-group@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-roving-focus": "1.1.19", "@radix-ui/react-toggle": "1.1.18", "@radix-ui/react-use-controllable-state": "1.2.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
@@ -3507,6 +3513,24 @@
 
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
+    "@radix-ui/react-toggle/@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
+
+    "@radix-ui/react-toggle/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
+
     "@react-email/markdown/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "@react-email/preview-server/esbuild": ["esbuild@0.25.10", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.10", "@esbuild/android-arm": "0.25.10", "@esbuild/android-arm64": "0.25.10", "@esbuild/android-x64": "0.25.10", "@esbuild/darwin-arm64": "0.25.10", "@esbuild/darwin-x64": "0.25.10", "@esbuild/freebsd-arm64": "0.25.10", "@esbuild/freebsd-x64": "0.25.10", "@esbuild/linux-arm": "0.25.10", "@esbuild/linux-arm64": "0.25.10", "@esbuild/linux-ia32": "0.25.10", "@esbuild/linux-loong64": "0.25.10", "@esbuild/linux-mips64el": "0.25.10", "@esbuild/linux-ppc64": "0.25.10", "@esbuild/linux-riscv64": "0.25.10", "@esbuild/linux-s390x": "0.25.10", "@esbuild/linux-x64": "0.25.10", "@esbuild/netbsd-arm64": "0.25.10", "@esbuild/netbsd-x64": "0.25.10", "@esbuild/openbsd-arm64": "0.25.10", "@esbuild/openbsd-x64": "0.25.10", "@esbuild/openharmony-arm64": "0.25.10", "@esbuild/sunos-x64": "0.25.10", "@esbuild/win32-arm64": "0.25.10", "@esbuild/win32-ia32": "0.25.10", "@esbuild/win32-x64": "0.25.10" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ=="],
@@ -3956,6 +3980,30 @@
     "@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.15", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-toggle/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
+
+    "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
 
     "@react-email/preview-server/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.10", "", { "os": "aix", "cpu": "ppc64" }, "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw=="],
 
@@ -4470,6 +4518,12 @@
     "@grpc/grpc-js/@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@grpc/proto-loader/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
+
+    "@radix-ui/react-toggle-group/@radix-ui/react-roving-focus/@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-toggle/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
 
     "@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -34,11 +34,11 @@ sequenceDiagram
 
 ## Workers
 
-| Worker  | Workspace  | Purpose                                               | Has `nodejs_compat` |
-| ------- | ---------- | ----------------------------------------------------- | :-----------------: |
-| **web** | `apps/web` | Edge router – receives all traffic, routes to app/api |         No          |
-| **app** | `apps/app` | SPA static assets (React, TanStack Router)            |         No          |
-| **api** | `apps/api` | Hono server – tRPC, Better Auth, webhooks             |         Yes         |
+| Worker  | Workspace  | Purpose                                                                | Has `nodejs_compat` |
+| ------- | ---------- | ---------------------------------------------------------------------- | :-----------------: |
+| **web** | `apps/web` | Marketing site + edge router – receives all traffic, routes to app/api |         No          |
+| **app** | `apps/app` | SPA static assets (React, TanStack Router)                             |         No          |
+| **api** | `apps/api` | Hono server – tRPC, Better Auth, webhooks                              |         Yes         |
 
 ### Web Worker
 

--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -1,50 +1,65 @@
-# UI
+# UI Components & Theming
 
-The project uses [shadcn/ui](https://ui.shadcn.com/) (new-york style) with [Tailwind CSS v4](https://tailwindcss.com/) for styling. Components live in `packages/ui/` and are shared across all apps in the monorepo.
+The project uses [shadcn/ui](https://ui.shadcn.com/) (new-york style) with [Tailwind CSS v4](https://tailwindcss.com/) for styling. Shared components live in `packages/ui/` and are imported as `@repo/ui`.
 
-## Component Management
+## Where Components Live
 
-Add components from the shadcn/ui registry:
+There are two homes for components, and the split matters:
+
+|               | `packages/ui/components/`               | `apps/app/components/`                  |
+| ------------- | --------------------------------------- | --------------------------------------- |
+| What          | shadcn/ui primitives – `Button`, `Card` | Product parts – `AuthForm`, `UserMenu`  |
+| Knows about   | React, Radix, and styling utilities     | Routes, queries, session, product rules |
+| Maintained by | The shadcn CLI (`bun ui:add`)           | You                                     |
+| Imported from | `@repo/ui`                              | `@/components/...`                      |
+
+A component belongs in `packages/ui` only if it would still make sense in a different app. Anything that reaches for a route, a query, or the session belongs in `apps/app/components`.
+
+## Adding Components
 
 ```bash
-# Add a single component
-bun ui:add button
-
-# Add multiple components
-bun ui:add dialog card select
-
-# Interactive mode – browse and select
-bun ui:add
-
-# List installed components
-bun ui:list
-
-# Update all installed components
-bun ui:update
+bun ui:add button              # Add a single component
+bun ui:add dialog card select  # Add several at once
+bun ui:add --all               # Add everything in the registry
+bun ui:essentials              # Add a curated starter set
+bun ui:list                    # List what's installed
+bun ui:update                  # Re-fetch installed components from the registry
 ```
 
-Run `bun ui:list` to see which components are currently installed.
+Adding a component writes the file and formats it with Prettier. It does **not** touch the barrel export, so add that line yourself:
 
-## Component Structure
+```ts
+// packages/ui/index.ts
+export * from "./components/toggle-group";
+```
 
-Components are stored directly in `packages/ui/components/` – one file per component:
+Without it, `import { ToggleGroup } from "@repo/ui"` won't resolve.
+
+::: warning Review what the CLI generates
+`bun ui:update` overwrites files in place, so local edits are lost – check `git diff` before committing. Registry output isn't uniform either: some components still emit `Context.Provider` and `useContext`, which this project's ESLint config rejects in favour of the React 19 forms (`<Context>` and `use()`).
+:::
+
+## Package Structure
 
 ```bash
 packages/ui/
-├── components/
-│   ├── avatar.tsx
+├── components/           # One file per component
 │   ├── button.tsx
 │   ├── card.tsx
-│   ├── ...
-│   └── textarea.tsx
+│   └── ...
+├── hooks/
 ├── lib/
 │   └── utils.ts          # cn() utility
-├── scripts/              # CLI tooling (add, list, update)
+├── scripts/              # CLI tooling (add, list, update, essentials)
+├── components.json       # shadcn CLI config – style, aliases, icon library
+├── styles.css            # Exists for the shadcn CLI; real styles live in the app
 ├── index.ts              # Barrel export
 └── package.json
 ```
 
-All components and utilities are re-exported from the package root (`index.ts`), so importing is straightforward:
+Inside `packages/ui`, the `@/` alias points at the package root – `@/lib/utils` means `packages/ui/lib/utils.ts`, not the app. Components import it that way because that is what the shadcn CLI generates, and it keeps the package self-contained.
+
+Everything is re-exported from the package root, so apps import from a single place:
 
 ```tsx
 import { Button, Card, CardHeader, CardTitle, Input, cn } from "@repo/ui";
@@ -60,8 +75,19 @@ import {
   CardHeader,
   CardTitle,
 } from "@repo/ui";
+import type { ReactNode } from "react";
 
-function FeatureCard({ title, description, children }) {
+type FeatureCardProps = {
+  title: string;
+  description: string;
+  children: ReactNode;
+};
+
+export function FeatureCard({
+  title,
+  description,
+  children,
+}: FeatureCardProps) {
   return (
     <Card>
       <CardHeader>
@@ -81,16 +107,21 @@ Use `cn()` (from `clsx` + `tailwind-merge`) for conditional and merged class nam
 ```tsx
 import { Button, cn } from "@repo/ui";
 
-<Button
-  className={cn(
-    "transition-colors",
-    isActive && "bg-primary text-primary-foreground",
-    isDisabled && "opacity-50 cursor-not-allowed",
-  )}
-/>;
+export function SaveButton({ isActive }: { isActive: boolean }) {
+  return (
+    <Button
+      className={cn(
+        "transition-colors",
+        isActive && "bg-primary text-primary-foreground",
+      )}
+    >
+      Save
+    </Button>
+  );
+}
 ```
 
-`tailwind-merge` resolves conflicts – later classes override earlier ones, so `cn("p-4", "p-6")` produces `"p-6"`.
+`tailwind-merge` resolves conflicts – later classes win, so `cn("p-4", "p-6")` produces `"p-6"`. That is what lets a `className` passed in from outside override a component's own defaults instead of fighting it on specificity.
 
 ## Theming
 
@@ -116,24 +147,46 @@ Theme colors are defined as CSS custom properties in `apps/app/styles/globals.cs
 }
 ```
 
-These variables are mapped to Tailwind utilities in `apps/app/tailwind.config.css` via `@theme inline`, so `bg-primary`, `text-muted-foreground`, etc. resolve to the CSS variables automatically.
+`apps/app/tailwind.config.css` maps these to Tailwind utilities via `@theme inline`, so `bg-primary`, `text-muted-foreground`, and the rest resolve to the variables automatically. To restyle the app, change the variables – every utility that references them follows.
+
+Most tokens come in pairs: `--primary` is the surface, `--primary-foreground` is the text drawn on it. Change one and check the other still reads against it, and make the matching edit in both the `:root` and `.dark` blocks – a color that passes contrast on white rarely does on near-black.
 
 ### Dark Mode
 
-Dark mode uses a custom Tailwind variant that toggles on the `dark` class:
+Dark mode uses a custom Tailwind variant keyed on the `dark` class:
 
 ```css
 /* apps/app/tailwind.config.css */
 @custom-variant dark (&:is(.dark *));
 ```
 
-### Customizing Colors
+`apps/app/lib/theme.tsx` owns that class. The user picks a `preference` – `light`, `dark`, or `system` – and the app renders the resolved `theme`, which is only ever `light` or `dark`:
 
-To change the color scheme, update the CSS variables in `globals.css`. The OKLCH values are independent – changing `--primary` automatically applies everywhere that uses `bg-primary`, `text-primary`, etc.
+```tsx
+import { useTheme } from "@/lib/theme";
+
+function ThemeButton() {
+  const { theme, preference, setPreference } = useTheme();
+
+  return (
+    <button onClick={() => setPreference(theme === "dark" ? "light" : "dark")}>
+      {preference === "system" ? `System (${theme})` : preference}
+    </button>
+  );
+}
+```
+
+The preference and the resolved theme are backed by Jotai atoms rather than a bespoke React context, so `theme` stays a derived value instead of state somebody has to keep in step. The atoms are private – `useTheme()` is the whole public API, and it reads from the `StoreProvider` at the root of `index.tsx` like every other atom in the app.
+
+The preference is persisted to `localStorage` and synced across tabs by [`atomWithStorage`](https://jotai.org/docs/utilities/storage). `<ThemeSync />`, mounted in `apps/app/index.tsx`, mirrors the resolved theme onto `<html>`: the `dark` class, the `color-scheme` property (so scrollbars and native form controls match), and `<meta name="theme-color">` for mobile browser chrome, read from the `--theme-color` variable in `globals.css`.
+
+An inline script in `apps/app/index.html` settles all three before first paint – without it, dark-mode users would see a white flash while the bundle loads. It duplicates a few lines of resolution logic on purpose, and it has to hardcode the two theme colors because no stylesheet is parsed that early. Its storage key and JSON encoding must match `theme.tsx`; its colors must match `--theme-color` in `globals.css`, as must `theme_color` in `public/site.manifest`.
+
+The switcher itself is a `ToggleGroup` – single-select toggle groups already carry radio semantics and arrow-key navigation, so there is no keyboard handling to maintain by hand.
 
 ## Tailwind Content Scanning
 
-The Tailwind config uses `@source` directives to scan both app code and the shared UI package:
+Tailwind v4 finds classes by scanning the files listed with `@source`. Both the app and the shared package have to be listed, or classes used only inside `packages/ui` are dropped from the production build:
 
 ```css
 /* apps/app/tailwind.config.css */
@@ -142,35 +195,30 @@ The Tailwind config uses `@source` directives to scan both app code and the shar
 @source "./lib/**/*.{js,ts,jsx,tsx}";
 @source "./routes/**/*.{js,ts,jsx,tsx}";
 @source "./components/**/*.{js,ts,jsx,tsx}";
+@source "./index.html";
+@source "./index.tsx";
 @source "../../packages/ui/components/**/*.{ts,tsx}";
 @source "../../packages/ui/lib/**/*.{ts,tsx}";
 @source "../../packages/ui/hooks/**/*.{ts,tsx}";
 ```
 
+Scanning is textual, so Tailwind only sees complete class names. `bg-red-500` is found; `` `bg-${color}-500` `` is not – map to whole class strings instead.
+
 ## Troubleshooting
 
-### Component not found
+**Import from `@repo/ui` fails.** Check the component is installed (`bun ui:list`) and exported from `packages/ui/index.ts` – `bun ui:add` does not add the export for you.
 
-If a component import fails, verify it's installed:
+**Styles missing in the built app but fine in dev.** The class lives in a file no `@source` covers, or it is assembled by string interpolation. See [Tailwind Content Scanning](#tailwind-content-scanning).
 
-```bash
-bun ui:list
-bun ui:add [component-name]
-```
+**Nothing is styled at all.** `apps/app/index.tsx` must import `./styles/globals.css`.
 
-### Styles not applying
-
-1. Check that `globals.css` is imported in `apps/app/index.tsx`
-2. Verify the Tailwind config includes `@source` paths for the UI package
-3. Check that the component file exists in `packages/ui/components/`
-
-### TypeScript errors
-
-Ensure the workspace reference is set up:
+**TypeScript can't resolve `@repo/ui`.** The consuming app needs both the path alias and the project reference in its `tsconfig.json`:
 
 ```json
-// apps/app/tsconfig.json
 {
+  "compilerOptions": {
+    "paths": { "@repo/ui": ["../../packages/ui"] }
+  },
   "references": [{ "path": "../../packages/ui" }]
 }
 ```

--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -57,9 +57,9 @@ packages/ui/
 └── package.json
 ```
 
-Inside `packages/ui`, the `@/` alias points at the package root – `@/lib/utils` means `packages/ui/lib/utils.ts`, not the app. Components import it that way because that is what the shadcn CLI generates, and it keeps the package self-contained.
+Components import `cn` as `@/lib/utils`, which is what the shadcn CLI generates. That alias resolves through the _consuming_ app's config rather than this package's, and it works only because every app keeps a `lib/utils` re-export shim. One component importing another must therefore use a relative path (`./toggle`) – the CLI's `@/components/…` form resolves into the app and fails the build there.
 
-Everything is re-exported from the package root, so apps import from a single place:
+Components and `cn` are re-exported from the package root, so apps import from a single place:
 
 ```tsx
 import { Button, Card, CardHeader, CardTitle, Input, cn } from "@repo/ui";
@@ -127,7 +127,7 @@ export function SaveButton({ isActive }: { isActive: boolean }) {
 
 ### CSS Variables
 
-Theme colors are defined as CSS custom properties in `apps/app/styles/globals.css` using the [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch) color space:
+Theme colors are defined as CSS custom properties using the [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch) color space. Each app owns its own set — `apps/app/styles/globals.css` is shown here, and `apps/web` keeps a matching copy for the marketing site:
 
 ```css
 :root {
@@ -176,7 +176,7 @@ function ThemeButton() {
 }
 ```
 
-The preference and the resolved theme are backed by Jotai atoms rather than a bespoke React context, so `theme` stays a derived value instead of state somebody has to keep in step. The atoms are private – `useTheme()` is the whole public API, and it reads from the `StoreProvider` at the root of `index.tsx` like every other atom in the app.
+The preference and the resolved theme are backed by Jotai atoms rather than a bespoke React context, so `theme` stays a derived value instead of state somebody has to keep in step. The atoms are private – `useTheme()` is the only way app code reads or sets the theme, and it resolves against the `StoreProvider` at the root of `index.tsx` like every other atom in the app.
 
 The preference is persisted to `localStorage` and synced across tabs by [`atomWithStorage`](https://jotai.org/docs/utilities/storage). `<ThemeSync />`, mounted in `apps/app/index.tsx`, mirrors the resolved theme onto `<html>`: the `dark` class, the `color-scheme` property (so scrollbars and native form controls match), and `<meta name="theme-color">` for mobile browser chrome, read from the `--theme-color` variable in `globals.css`.
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -3,7 +3,7 @@ shadcn/ui component library (new-york style, Radix primitives, Tailwind v4). Con
 ## Scope
 
 - Only generic primitives belong here. If a component imports a route, a query, or the session, it belongs in `apps/app/components/` instead.
-- Nothing here imports from `apps/` or `db/`. The package must stay droppable into another app as-is.
+- Nothing here imports application or domain code (`apps/`, `db/`). Consumers still have to supply the pieces below: a `lib/utils` shim, Tailwind `@source` entries, and the theme tokens.
 - `@/` is only safe for `@/lib/utils`. It resolves via each _consumer's_ tsconfig (both apps map `@/*` to their own root), and it works solely because every consumer keeps a `lib/utils` re-export shim. Keep that form — the CLI regenerates it, and rewriting it to `@repo/ui` creates a cycle.
 - Import one component from another **relatively** (`./toggle`). The CLI emits `@/components/toggle`, which resolves into the consuming app and fails the build there — `apps/web` has no `components/toggle`. Fix it after every `bun ui:add`/`ui:update`.
 
@@ -22,9 +22,9 @@ shadcn/ui component library (new-york style, Radix primitives, Tailwind v4). Con
 ## Styling
 
 - Every component accepts `className` and passes it through `cn()` last — directly, or via the `className` slot on a `cva` variants call — so callers can override defaults without a specificity fight.
-- Use theme tokens (`bg-primary`, `text-muted-foreground`), never raw colors. Token values live in `apps/app/styles/globals.css`; `styles.css` here exists only to satisfy the shadcn CLI.
+- Use theme tokens (`bg-primary`, `text-muted-foreground`), never raw colors. Each consumer defines the values in its own `styles/globals.css` — `apps/app` and `apps/web` keep separate copies, so a palette change means editing both. `styles.css` here exists only to satisfy the shadcn CLI.
 - Class names must appear as complete literals — Tailwind scans text, so `` `bg-${color}-500` `` produces nothing.
-- Consuming apps must `@source` this package's `components/`, `lib/`, and `hooks/` in their Tailwind config.
+- Consuming apps must `@source` every directory here that holds class names, or those classes are stripped from their build.
 
 ## Conventions
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,32 @@
+shadcn/ui component library (new-york style, Radix primitives, Tailwind v4). Consumed as `@repo/ui`.
+
+## Scope
+
+- Only generic primitives belong here. If a component imports a route, a query, or the session, it belongs in `apps/app/components/` instead.
+- Nothing here imports from `apps/` or `db/`. The package must stay droppable into another app as-is.
+- `@/` resolves to the package root (`packages/ui/tsconfig.json` maps `@/*` → `./*`). `@/lib/utils` is this package's `lib/utils.ts`, not the app's. Leave CLI-generated imports as they are — rewriting them to `@repo/ui` creates a cycle.
+
+## Adding and Updating Components
+
+- Use `bun ui:add <component>`; don't hand-write files the registry already has. `bun ui:add` with no arguments prints help and exits non-zero.
+- `bun ui:add` does NOT update `index.ts`. Add `export * from "./components/<name>";` yourself, or the import from `@repo/ui` won't resolve.
+- The CLI installs any Radix packages the component needs. Review and commit the resulting `package.json` and `bun.lock` changes.
+- `bun ui:update` overwrites every installed component in place. Review `git diff` before committing; local edits are lost.
+- Registry output is not uniform — read what it generated. `packages/ui` lints with `--max-warnings 0`, so convert React 18 patterns before committing:
+  - `<Context.Provider value={x}>` → `<Context value={x}>` (`@eslint-react/no-context-provider`)
+  - `React.useContext(C)` → `React.use(C)` (`@eslint-react/no-use-context`)
+- Strip the `"use client"` directive when it appears — no RSC here, so it is inert.
+- `no-forward-ref` is off for this package — generated `forwardRef` usage is fine.
+
+## Styling
+
+- Every component accepts `className` and passes it through `cn()` last — directly, or via the `className` slot on a `cva` variants call — so callers can override defaults without a specificity fight.
+- Use theme tokens (`bg-primary`, `text-muted-foreground`), never raw colors. Token values live in `apps/app/styles/globals.css`; `styles.css` here exists only to satisfy the shadcn CLI.
+- Class names must appear as complete literals — Tailwind scans text, so `` `bg-${color}-500` `` produces nothing.
+- Consuming apps must `@source` this package's `components/`, `lib/`, and `hooks/` in their Tailwind config.
+
+## Conventions
+
+- Named exports only — no default exports.
+- Variants via `class-variance-authority`; export the variants object when another component composes it (see `toggle.tsx` → `toggle-group.tsx`).
+- Prefer a Radix primitive over hand-rolled behavior — it brings the ARIA roles and keyboard handling with it. `ToggleGroup type="single"` already renders `role="radiogroup"` with `role="radio"` items and arrow-key navigation, so callers add no keyboard code.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -4,7 +4,8 @@ shadcn/ui component library (new-york style, Radix primitives, Tailwind v4). Con
 
 - Only generic primitives belong here. If a component imports a route, a query, or the session, it belongs in `apps/app/components/` instead.
 - Nothing here imports from `apps/` or `db/`. The package must stay droppable into another app as-is.
-- `@/` resolves to the package root (`packages/ui/tsconfig.json` maps `@/*` → `./*`). `@/lib/utils` is this package's `lib/utils.ts`, not the app's. Leave CLI-generated imports as they are — rewriting them to `@repo/ui` creates a cycle.
+- `@/` is only safe for `@/lib/utils`. It resolves via each _consumer's_ tsconfig (both apps map `@/*` to their own root), and it works solely because every consumer keeps a `lib/utils` re-export shim. Keep that form — the CLI regenerates it, and rewriting it to `@repo/ui` creates a cycle.
+- Import one component from another **relatively** (`./toggle`). The CLI emits `@/components/toggle`, which resolves into the consuming app and fails the build there — `apps/web` has no `components/toggle`. Fix it after every `bun ui:add`/`ui:update`.
 
 ## Adding and Updating Components
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -15,8 +15,11 @@ import { Button, Card, Input, cn } from "@repo/ui";
 ```bash
 bun ui:add <component>    # Add a shadcn/ui component
 bun ui:list               # List installed components
+bun ui:update             # Re-fetch installed components
 bun ui:essentials         # Install curated essential set
 ```
+
+See [AGENTS.md](./AGENTS.md) for the conventions these commands assume.
 
 ## Structure
 
@@ -27,4 +30,6 @@ lib/              # Utilities (cn function)
 scripts/          # Component management tools
 ```
 
-Consuming apps must include `@source "../../packages/ui/components/**/*.{ts,tsx}"` in their Tailwind config.
+Consuming apps must `@source` this package's `components/`, `lib/`, and `hooks/` in
+their Tailwind config, or classes used only here are stripped from the build. See
+[apps/app/tailwind.config.css](../../apps/app/tailwind.config.css) for the full list.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -30,6 +30,6 @@ lib/              # Utilities (cn function)
 scripts/          # Component management tools
 ```
 
-Consuming apps must `@source` this package's `components/`, `lib/`, and `hooks/` in
-their Tailwind config, or classes used only here are stripped from the build. See
-[apps/app/tailwind.config.css](../../apps/app/tailwind.config.css) for the full list.
+Consuming apps must `@source` every directory here that holds class names, or those
+classes are stripped from their build. See
+[apps/app/tailwind.config.css](../../apps/app/tailwind.config.css) for an example.

--- a/packages/ui/components/toggle-group.tsx
+++ b/packages/ui/components/toggle-group.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+});
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext>
+  </ToggleGroupPrimitive.Root>
+));
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.use(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+});
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };

--- a/packages/ui/components/toggle-group.tsx
+++ b/packages/ui/components/toggle-group.tsx
@@ -3,8 +3,8 @@ import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-// Relative, not "@/components/toggle": consumers alias "@/" to their own root,
-// so the CLI's form resolves into the app and breaks the build. See AGENTS.md.
+// Relative, not the CLI's "@/components/toggle": "@/" resolves into the
+// consuming app, which breaks its build. See AGENTS.md.
 import { toggleVariants } from "./toggle";
 
 const ToggleGroupContext = React.createContext<

--- a/packages/ui/components/toggle-group.tsx
+++ b/packages/ui/components/toggle-group.tsx
@@ -3,7 +3,9 @@ import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-import { toggleVariants } from "@/components/toggle";
+// Relative, not "@/components/toggle": consumers alias "@/" to their own root,
+// so the CLI's form resolves into the app and breaks the build. See AGENTS.md.
+import { toggleVariants } from "./toggle";
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants>

--- a/packages/ui/components/toggle.tsx
+++ b/packages/ui/components/toggle.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle, toggleVariants };

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -18,6 +18,8 @@ export * from "./components/separator";
 export * from "./components/skeleton";
 export * from "./components/switch";
 export * from "./components/textarea";
+export * from "./components/toggle";
+export * from "./components/toggle-group";
 
 // Export utilities
 export * from "./lib/utils";

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,7 +1,8 @@
 /**
  * @file UI component library entrypoint.
  *
- * Re-exports all shadcn/ui components, utilities, and hooks.
+ * Re-exports the installed components and `cn`. Add a line here after
+ * `bun ui:add` – the CLI does not.
  */
 
 export * from "./components/avatar";
@@ -21,7 +22,4 @@ export * from "./components/textarea";
 export * from "./components/toggle";
 export * from "./components/toggle-group";
 
-// Export utilities
 export * from "./lib/utils";
-
-// Export hooks

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,8 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-toggle": "^1.1.18",
+    "@radix-ui/react-toggle-group": "^1.1.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.574.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   cacheDir: "./.cache/vite",
   test: {
-    projects: ["apps/api", "apps/app"],
+    projects: ["apps/api/vitest.config.ts", "apps/app/vite.config.ts"],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   cacheDir: "./.cache/vite",
   test: {
-    projects: ["apps/api/vitest.config.ts", "apps/app/vite.config.ts"],
+    projects: ["apps/api", "apps/app"],
   },
 });


### PR DESCRIPTION
### Summary

Connects the Settings appearance control to a working theme system: a three-way preference (light / dark / system), persisted, synced across tabs, and applied before first paint.

### Design decisions

**Jotai atoms rather than a React context.** The app already uses Jotai for shared state, and the effective theme is _derived_ from the preference — as a computed atom it cannot fall out of step. Both atoms are private, and `useTheme()` declares its return type explicitly so Jotai's `RESET` token and updater overloads stay out of app code.

**`preference` vs `theme`.** `preference` is what the user chose (`light | dark | system`); `theme` is what renders (`light | dark`). Only the preference is persisted, and nothing is written until the user picks one — so an untouched install keeps following the OS.

**The inline script in `index.html` duplicates resolution logic on purpose.** Nothing else runs before first paint, so a dark-mode user would otherwise get a flash of white while the bundle loads. `theme.test.tsx` pins its storage key and encoding.

**Theme colors live in CSS.** `ThemeSync` reads `--theme-color` from `globals.css` rather than holding hex values in TypeScript. `index.html` and `site.manifest` must repeat them since they load before any stylesheet — a manual contract recorded in `apps/app/AGENTS.md`, and one no test can cover, since Vitest resolves CSS imports to an empty string.

**Radix `ToggleGroup` instead of custom keyboard handling.** `type="single"` renders `role="radiogroup"` with `role="radio"` items and arrow-key navigation, so the switcher carries no keyboard code of its own.

### Worth a reviewer's attention

- `apps/app/vitest.setup.ts` installs a real `localStorage`: Node's Web Storage global shadows happy-dom's and stays undefined, which blocked every persistence test.
- Components in `packages/ui` must import each other **relatively**. The shadcn CLI emits `@/components/…`, but `@/` resolves through the _consuming_ app — that form builds in `apps/app` and fails in `apps/web`.
- Also rewrites `docs/frontend/ui.md` and adds `packages/ui/AGENTS.md` for the shadcn workflow.

### Testing

`bun test` · `bun typecheck` · `bun lint` · `bun build` · `bun docs:build` all clean.

Checked in Chromium against the production build: with a stored dark preference the page loads with `.dark`, `color-scheme: dark`, and `theme-color: #0f0f0f`, and cross-tab `storage` events update all three.
