### PR TITLE
feat(app): unify devtools behind one shell

### DIFF
--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -42,4 +42,5 @@ Client-side SPA – no SSR. All rendering happens in the browser.
 ## Error Handling
 
 - `AppErrorBoundary` (root) shows generic error UI. `AuthErrorBoundary` (protected routes) catches 401/UNAUTHORIZED and shows sign-in recovery UI; 403 falls through to generic handler.
+- `AppErrorBoundary` wraps the outlet only. `Devtools` mounts as its sibling with a silent boundary of its own, so neither dev tooling nor app UI can unmount the other – don't move it inside.
 - Utilities in `lib/errors.ts`: `getErrorStatus()`, `isUnauthenticatedError()`, `getErrorMessage()`.

--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -42,5 +42,5 @@ Client-side SPA – no SSR. All rendering happens in the browser.
 ## Error Handling
 
 - `AppErrorBoundary` (root) shows generic error UI. `AuthErrorBoundary` (protected routes) catches 401/UNAUTHORIZED and shows sign-in recovery UI; 403 falls through to generic handler.
-- `AppErrorBoundary` wraps the outlet only. `Devtools` mounts as its sibling with a silent boundary of its own, so neither dev tooling nor app UI can unmount the other – don't move it inside.
+- `Devtools` mounts as a sibling of `AppErrorBoundary`, not inside it, and carries its own silent boundary – neither can unmount the other.
 - Utilities in `lib/errors.ts`: `getErrorStatus()`, `isUnauthenticatedError()`, `getErrorMessage()`.

--- a/apps/app/components/devtools.tsx
+++ b/apps/app/components/devtools.tsx
@@ -4,19 +4,16 @@ import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { ErrorBoundary } from "react-error-boundary";
 
 /**
- * Router and Query devtools behind one shell, so development gets a single
- * trigger instead of two floating logos. Mounted by the root route, which puts
- * it under both `RouterProvider` and `QueryClientProvider` – each panel finds
- * its own context from there.
+ * Router and Query devtools behind one shell – one trigger instead of two
+ * floating logos. The root route mounts it under `RouterProvider` and
+ * `QueryClientProvider`, where each panel finds its context, and outside
+ * `AppErrorBoundary` so a devtools crash can't raise the app's error UI. Its own
+ * boundary renders nothing, because React unmounts the whole tree for a render
+ * error no boundary catches.
  *
- * Render failures stay contained in both directions: the root route keeps this
- * outside `AppErrorBoundary` so a devtools crash can't raise the app's error UI,
- * and the boundary below renders nothing so it can't take the app down with it –
- * React unmounts the whole tree for a render error no boundary catches.
- *
- * Only the shell is wired up, not `@tanstack/devtools-vite`. Its source
- * inspection and console piping change how every component is compiled and
- * logged, and the guard below already keeps devtools out of production builds.
+ * `@tanstack/devtools-vite` is deliberately absent: its source inspection and
+ * console piping change how every component is compiled and logged, and the dev
+ * guard below is enough to keep devtools out of production.
  */
 export function Devtools() {
   if (!import.meta.env.DEV) return null;
@@ -26,21 +23,19 @@ export function Devtools() {
       <TanStackDevtools
         config={{
           hideUntilHover: true,
-          // The shell's default `Ctrl+~` cannot be typed: it matches the exact
-          // set of keys held, and a US layout needs Shift to reach `~`. `X` is
-          // the replacement because Chrome, Firefox, and Edge all leave
-          // Ctrl+Shift+X unbound – Ctrl+Shift+D is "bookmark all tabs" in every
-          // one of them. Developers can rebind it from the settings tab.
+          // The default `Ctrl+~` can't be typed – the shell matches the exact
+          // set of keys held, and a US layout needs Shift to reach `~`. The
+          // mnemonic `Ctrl+Shift+D` is taken: "bookmark all tabs" in Chrome,
+          // Firefox, and Edge. `X` is unclaimed in all three.
           openHotkey: ["Control", "Shift", "X"],
         }}
         plugins={[
           {
-            // Explicit IDs: generated ones embed the plugin's array index, so
-            // adding or reordering a panel would orphan the persisted layout.
+            // Generated IDs embed the array index, so reordering panels would
+            // orphan the persisted layout.
             id: "router",
             name: "Router",
-            // Opens whenever no panel is active – on a first run, and again if
-            // the developer closes every panel and reloads.
+            // Applies whenever no panel is active, not just the first run.
             defaultOpen: true,
             render: <TanStackRouterDevtoolsPanel />,
           },

--- a/apps/app/components/devtools.tsx
+++ b/apps/app/components/devtools.tsx
@@ -1,0 +1,52 @@
+import { TanStackDevtools } from "@tanstack/react-devtools";
+import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";
+import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
+import { ErrorBoundary } from "react-error-boundary";
+
+/**
+ * Router and Query devtools behind one shell, so development gets a single
+ * trigger instead of two floating logos. Mounted by the root route, which puts
+ * it under both `RouterProvider` and `QueryClientProvider` – each panel finds
+ * its own context from there.
+ *
+ * Render failures stay contained in both directions: the root route keeps this
+ * outside `AppErrorBoundary` so a devtools crash can't raise the app's error UI,
+ * and the boundary below renders nothing so it can't take the app down with it –
+ * React unmounts the whole tree for a render error no boundary catches.
+ *
+ * Only the shell is wired up, not `@tanstack/devtools-vite`. Its source
+ * inspection and console piping change how every component is compiled and
+ * logged, and the guard below already keeps devtools out of production builds.
+ */
+export function Devtools() {
+  if (!import.meta.env.DEV) return null;
+
+  return (
+    <ErrorBoundary fallback={null}>
+      <TanStackDevtools
+        config={{
+          hideUntilHover: true,
+          // The shell's default `Ctrl+~` cannot be typed: it matches the exact
+          // set of keys held, and a US layout needs Shift to reach `~`. `X` is
+          // the replacement because Chrome, Firefox, and Edge all leave
+          // Ctrl+Shift+X unbound – Ctrl+Shift+D is "bookmark all tabs" in every
+          // one of them. Developers can rebind it from the settings tab.
+          openHotkey: ["Control", "Shift", "X"],
+        }}
+        plugins={[
+          {
+            // Explicit IDs: generated ones embed the plugin's array index, so
+            // adding or reordering a panel would orphan the persisted layout.
+            id: "router",
+            name: "Router",
+            // Opens whenever no panel is active – on a first run, and again if
+            // the developer closes every panel and reloads.
+            defaultOpen: true,
+            render: <TanStackRouterDevtoolsPanel />,
+          },
+          { id: "query", name: "Query", render: <ReactQueryDevtoolsPanel /> },
+        ]}
+      />
+    </ErrorBoundary>
+  );
+}

--- a/apps/app/index.tsx
+++ b/apps/app/index.tsx
@@ -1,5 +1,4 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -25,13 +24,8 @@ root.render(
     <StoreProvider>
       <ThemeSync />
       <QueryClientProvider client={queryClient}>
+        {/* Router and Query devtools share one shell in the root route. */}
         <RouterProvider router={router} />
-        {import.meta.env.DEV && (
-          <ReactQueryDevtools
-            initialIsOpen={false}
-            buttonPosition="bottom-right"
-          />
-        )}
       </QueryClientProvider>
     </StoreProvider>
   </StrictMode>,

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -32,6 +32,7 @@
     "@repo/api": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
+    "@tanstack/react-devtools": "^0.10.10",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.27",

--- a/apps/app/routes/__root.tsx
+++ b/apps/app/routes/__root.tsx
@@ -1,7 +1,7 @@
 import { AppErrorBoundary } from "@/components/auth";
+import { Devtools } from "@/components/devtools";
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
-import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
 // Only queryClient in context - needed for beforeLoad prefetching.
 // Auth client is a singleton (no hook equivalent in Better Auth).
@@ -13,9 +13,11 @@ export const Route = createRootRouteWithContext<{
 
 export function Root() {
   return (
-    <AppErrorBoundary>
-      <Outlet />
-      {import.meta.env.DEV && <TanStackRouterDevtools />}
-    </AppErrorBoundary>
+    <>
+      <AppErrorBoundary>
+        <Outlet />
+      </AppErrorBoundary>
+      <Devtools />
+    </>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
         "@repo/api": "workspace:*",
         "@repo/typescript-config": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
+        "@tanstack/react-devtools": "^0.10.10",
         "@tanstack/react-query-devtools": "^5.101.4",
         "@tanstack/react-router-devtools": "^1.167.1",
         "@tanstack/router-plugin": "^1.168.27",
@@ -623,6 +624,10 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
 
+    "@neodrag/core": ["@neodrag/core@3.0.0-next.11", "", {}, "sha512-3WQWxyrbxiaK9zS5JU2wJsW2gpoQlZBXVghduBh61JpqaeE0T0cte8R0qYK2RuJo3J2TYQYqxO19CpG/C1i5eg=="],
+
+    "@neodrag/solid": ["@neodrag/solid@3.0.0-next.11", "", { "peerDependencies": { "@neodrag/core": "3.0.0-next.11", "solid-js": "^1.0.0" } }, "sha512-vCBIn/pimjWMQ6vhTS2/O1XNAwzVtc4eUhdbQ91WykbZWWqQ5NocDXt/1OdYrEkeRzJcpCv8wEz5PnMkgKP81Q=="],
+
     "@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
@@ -897,6 +902,18 @@
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
 
+    "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.6", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw=="],
+
+    "@solid-primitives/keyboard": ["@solid-primitives/keyboard@1.3.7", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.6", "@solid-primitives/rootless": "^1.5.4", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-558RPNYnXx4nGh537DSqAn4xMrC8iFipl/5+xzgzWoTNFst4RnUN3BOLmtDjJ0UGGoQXVMALYR3bNOHM0xnt1Q=="],
+
+    "@solid-primitives/resize-observer": ["@solid-primitives/resize-observer@2.2.0", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.6", "@solid-primitives/rootless": "^1.5.4", "@solid-primitives/static-store": "^0.1.4", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-9Fuu/EWBeGj+atGHRJp70HKhdfalmpjwxY8a32NZixdLNmfCJ45AfhLQNr6uOzETbbiMx4iCKlTrJ8KZCHC2Ww=="],
+
+    "@solid-primitives/rootless": ["@solid-primitives/rootless@1.5.4", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-TOIZa1VUfVJ+9nkCcRajw3U4t9vBOP1HxX1WHNTbXq32mXwlqTvUnC4CRIilohcryBkT9u2ZkhUDSHRTaGp55g=="],
+
+    "@solid-primitives/static-store": ["@solid-primitives/static-store@0.1.4", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-LgtVaVBtB7EbmS4+M0b8xY5Iq6pUWXBsIC4VgtrFKDGDdyCaDt88sHk0fUlx1Enxm/XZnZyLXJABRoa39RjJqA=="],
+
+    "@solid-primitives/utils": ["@solid-primitives/utils@6.4.1", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-ISSB5QX1qP2ynrheIpYwc4oKR5Ny4siNuUyf1qZniy+Il+p/PtDB0QK1Dnle8noiHpwRD3gpPdubOC3qI/Zamg=="],
+
     "@speed-highlight/core": ["@speed-highlight/core@1.2.23", "", {}, "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
@@ -935,11 +952,23 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
+    "@tanstack/devtools": ["@tanstack/devtools@0.14.0", "", { "dependencies": { "@neodrag/solid": "3.0.0-next.11", "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "@tanstack/devtools-ui": "0.7.0", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-tN0SEi1BVaJYtkZbgYpvLsInjwNRAZkR3r6slSvz9Jm+bfkhcdjuOSrZp0cAwOGwdnauHZ1mYgtfe2AfC/V1NQ=="],
+
+    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.5.0" } }, "sha512-cG3iZkGWCwN330bLBKa8+9r4Of2AXNoz2zUqcsy/4XsD3105ghVBx78cGyvJj9fSclNomPxoqAnDGXXhg1WLvA=="],
+
+    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.2", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-2LHzhwBFlKHCcklsQrGe8TeyjHd4XAF8nuCO6wHmva5fePUkJUULbu6CsCNAlGlCi0KkEsMXZSvRdR4HgMq4yA=="],
+
+    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.5.0", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-H+OH3zC6Vhu/K0NaVfQKknEKawc/+2PT+D3SB3Ox0V8SiMlTo0abbmH2rH0721R2aNYbjdMXA1oENOd8E2UVoA=="],
+
+    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.7.0", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-px/a+JgRSVHDj/hID1cwfsIi+ly5l7t3Yw7fLw4G556HXCNgDri36fupt9h7oBeEKntpsx3ep/XtZn51rrCv2g=="],
+
     "@tanstack/history": ["@tanstack/history@1.162.1", "", {}, "sha512-DR9t6lfLVdrjgCwpglrR9DR7Ok8/HlXjcOE+goWXF3zyuLUO/ug7vMbSFxTqrQTtbRghJfyhmIZ0S6LhPIy44w=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.4", "", {}, "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="],
 
     "@tanstack/query-devtools": ["@tanstack/query-devtools@5.101.4", "", {}, "sha512-z5IPHnDX3aUWeTWlRKLyooBQekaCAw4xRpZqPQ390RiWTDBcTynjpPT221BArw0u2+pnQMdGvPQI9YNNubBcmA=="],
+
+    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.10", "", { "dependencies": { "@tanstack/devtools": "0.14.0" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-hYH34MSVbajs1pUc22ftSapyKQp2gOh0w34a7ouYOdIcbXD6YPckSR2YpAWGq1rrs6N0l/rvV6LM/G1pgN5ARg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.101.4", "", { "dependencies": { "@tanstack/query-core": "5.101.4" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA=="],
 
@@ -2611,6 +2640,8 @@
 
     "socket.io-parser": ["socket.io-parser@4.2.7", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg=="],
 
+    "solid-js": ["solid-js@1.9.14", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -3136,6 +3167,10 @@
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "solid-js/seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "solid-js/seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/docs/frontend/routing.md
+++ b/docs/frontend/routing.md
@@ -34,7 +34,7 @@ The two route groups serve different auth requirements:
 
 ## Root Route
 
-The root route (`__root.tsx`) creates the router context and wraps everything in an error boundary:
+The root route (`__root.tsx`) creates the router context and wraps the outlet in an error boundary:
 
 ```tsx
 // apps/app/routes/__root.tsx
@@ -46,15 +46,23 @@ export const Route = createRootRouteWithContext<{
 
 function Root() {
   return (
-    <AppErrorBoundary>
-      <Outlet />
-      {import.meta.env.DEV && <TanStackRouterDevtools />}
-    </AppErrorBoundary>
+    <>
+      <AppErrorBoundary>
+        <Outlet />
+      </AppErrorBoundary>
+      <Devtools />
+    </>
   );
 }
 ```
 
 The `queryClient` in context is what makes `beforeLoad` guards possible – route guards can prefetch or read cached data before rendering.
+
+## Devtools
+
+`components/devtools.tsx` puts the Router and Query panels behind one TanStack Devtools shell, so development gets a single trigger instead of two floating logos. It renders `null` outside dev, and it mounts outside `AppErrorBoundary` with a silent boundary of its own – a render failure in either subtree can't replace or unmount the other.
+
+The trigger stays hidden until you hover its corner, and `Ctrl+Shift+X` opens the panel without it. Router is the panel you land on whenever no other one is active. Position, theme, panel side, and the hotkey are settings the shell persists per browser – the `config` prop only seeds them, and the panel's settings tab wins from then on.
 
 ## Auth Guards
 

--- a/docs/frontend/routing.md
+++ b/docs/frontend/routing.md
@@ -60,9 +60,17 @@ The `queryClient` in context is what makes `beforeLoad` guards possible – rout
 
 ## Devtools
 
-`components/devtools.tsx` puts the Router and Query panels behind one TanStack Devtools shell, so development gets a single trigger instead of two floating logos. It renders `null` outside dev, and it mounts outside `AppErrorBoundary` with a silent boundary of its own – a render failure in either subtree can't replace or unmount the other.
+`components/devtools.tsx` mounts [TanStack Devtools](https://tanstack.com/devtools/latest) with the Router and Query panels as plugins of one shell. It renders `null` outside development, so nothing reaches your production bundle.
 
-The trigger stays hidden until you hover its corner, and `Ctrl+Shift+X` opens the panel without it. Router is the panel you land on whenever no other one is active. Position, theme, panel side, and the hotkey are settings the shell persists per browser – the `config` prop only seeds them, and the panel's settings tab wins from then on.
+::: tip
+
+The trigger is invisible until you hover the bottom-right corner. `Ctrl+Shift+X` opens the panel without it.
+
+:::
+
+Position, theme, panel side, and the hotkey are settings the shell persists per browser. The `config` prop only seeds them – once you change one from the panel's settings tab, that value wins.
+
+`Devtools` sits outside `AppErrorBoundary` and carries its own boundary, so a render failure in either subtree can't take down the other.
 
 ## Auth Guards
 


### PR DESCRIPTION
Router and Query devtools each rendered their own floating logo, one in each bottom corner of the app. Both now mount as plugins of a single [TanStack Devtools](https://tanstack.com/devtools/latest) shell, whose trigger stays hidden until its corner is hovered.

### Decisions

- **`Ctrl+Shift+X` hotkey** – the shell's default `Ctrl+~` can't be typed: it matches the exact set of keys held, and a US layout needs Shift to reach `~`. `Ctrl+Shift+D` was the obvious mnemonic, but it is "bookmark all tabs" in Chrome, Firefox, and Edge; `Ctrl+Shift+X` is absent from their published shortcut tables. Rebindable from the shell's settings tab.
- **Failure isolation** – devtools sit outside `AppErrorBoundary` and carry a silent boundary of their own. Both halves matter: React unmounts the whole tree for a render error no boundary catches, so without its own boundary a devtools crash would blank the app; inside `AppErrorBoundary` it would instead raise the app's error UI.
- **Explicit plugin IDs** – generated IDs embed the plugin's array index (`router-0`), and the shell drops persisted layout entries whose IDs it no longer recognises. Without fixed IDs, adding or reordering a panel silently orphans the saved workspace.
- **`defaultOpen` on Router** – otherwise the panel opens on an empty "No plugin open" screen. It applies whenever no panel is active, not only on a first run.
- **No `@tanstack/devtools-vite`** – its source inspection and console piping change how every component is compiled and logged, and the production stripping it is mainly sold on is already handled by the `import.meta.env.DEV` guard.

### Verification beyond CI

- Production bundle greps clean for `TanStackDevtools`, `hideUntilHover`, `solid-js`, and `neodrag` – the Solid-based shell and its new lockfile entries stay out of production.
- Driven in a browser: trigger at `opacity: 0` until hovered, `Ctrl+Shift+X` toggles the panel, both panels render live data, persisted layout uses the stable `router` ID.
- Failure isolation tested by swapping a panel for a component that throws during render – the shell vanished, the app stayed usable, and React still logged the error.
