### PR TITLE
style: let Oxfmt own import order

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,6 +2,11 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   // Everything else is an Oxfmt default; only the deltas belong here.
   "printWidth": 80,
+  // Import order belongs to the formatter, so it is identical for everyone and
+  // checked in CI. The defaults are the point: side-effect imports keep their
+  // position, and `#*` subpath imports form their own group, separate from
+  // `@repo/*` packages.
+  "sortImports": true,
   // .gitignore is read automatically. These are tracked files that are
   // generated or machine-owned, so formatting them only creates diff noise.
   "ignorePatterns": ["**/*.gen.ts", "bun.lock"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
-  },
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
   "editor.quickSuggestions": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ bun deploy:{staging,production} # Build and deploy api → app → web; no migra
 - Use precise TypeScript types. Avoid `any` and unnecessary type assertions – let the compiler enforce correctness.
 - Document non-obvious trade-offs and decisions. Explain why, not what – every word must add value.
 
+## Formatting
+
+- Import order belongs to Oxfmt (`sortImports` in `.oxfmtrc.json`): applied by `bun run format`, checked by `bun run format:check` in CI and by lint-staged on commit. Do not reintroduce an editor code action or a lint rule for it.
+
 ## Markdown
 
 - Prose is not hard-wrapped: keep each paragraph on one line and use paragraphs, lists and headings for structure. Oxfmt enforces this with `proseWrap: "never"`.

--- a/apps/api/dev.ts
+++ b/apps/api/dev.ts
@@ -4,12 +4,14 @@
  * Requires wrangler.jsonc with HYPERDRIVE_CACHED and HYPERDRIVE_UNCACHED bindings.
  */
 
+import { parseArgs } from "node:util";
+
 import { Hono } from "hono";
 import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { secureHeaders } from "hono/secure-headers";
-import { parseArgs } from "node:util";
 import { getPlatformProxy } from "wrangler";
+
 import api from "./index.js";
 import { createAuth } from "./lib/auth.js";
 import type { AppContext } from "./lib/context.js";

--- a/apps/api/lib/app.ts
+++ b/apps/api/lib/app.ts
@@ -6,6 +6,7 @@
 
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { Hono } from "hono";
+
 import { billingRouter } from "../routers/billing.js";
 import { configRouter } from "../routers/config.js";
 import type { AppContext } from "./context.js";

--- a/apps/api/lib/auth.test.ts
+++ b/apps/api/lib/auth.test.ts
@@ -1,6 +1,7 @@
 import { member, organization, user } from "@repo/db";
 import { createTestDatabase } from "@repo/db/testing";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
 import { findInitialOrganization } from "./auth";
 
 const { db, reset, close } = await createTestDatabase();

--- a/apps/api/lib/auth.ts
+++ b/apps/api/lib/auth.ts
@@ -13,6 +13,7 @@ import { anonymous, organization } from "better-auth/plugins";
 import { emailOTP } from "better-auth/plugins/email-otp";
 import { and, eq } from "drizzle-orm";
 import Stripe from "stripe";
+
 import { sendOTP, sendPasswordReset, sendVerificationEmail } from "./email";
 import type { Env } from "./env";
 import { canManageOrgBilling, planLimits } from "./plans";

--- a/apps/api/lib/context.ts
+++ b/apps/api/lib/context.ts
@@ -1,5 +1,6 @@
 import type { Database } from "@repo/db";
 import type { CreateHTTPContextOptions } from "@trpc/server/adapters/standalone";
+
 import type { Auth, AuthSession, AuthUser } from "./auth.js";
 import type { Env } from "./env.js";
 

--- a/apps/api/lib/email.ts
+++ b/apps/api/lib/email.ts
@@ -7,6 +7,7 @@ import {
 } from "@repo/email";
 import { Resend } from "resend";
 import { z } from "zod";
+
 import type { Env } from "./env";
 
 export interface EmailOptions {

--- a/apps/api/lib/trpc.ts
+++ b/apps/api/lib/trpc.ts
@@ -1,5 +1,6 @@
 import { initTRPC, TRPCError, type TRPCProcedureBuilder } from "@trpc/server";
 import { flattenError, ZodError } from "zod";
+
 import type { TRPCContext } from "./context.js";
 
 const t = initTRPC.context<TRPCContext>().create({

--- a/apps/api/routers/billing.test.ts
+++ b/apps/api/routers/billing.test.ts
@@ -1,6 +1,7 @@
 import { member, organization, subscription, user } from "@repo/db";
 import { createTestDatabase } from "@repo/db/testing";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
 import type { TRPCContext } from "../lib/context";
 import { createCallerFactory } from "../lib/trpc";
 import { billingRouter } from "./billing";

--- a/apps/api/routers/billing.ts
+++ b/apps/api/routers/billing.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+
 import {
   canManageOrgBilling,
   planLimits,

--- a/apps/api/worker.ts
+++ b/apps/api/worker.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { secureHeaders } from "hono/secure-headers";
+
 import app from "./lib/app.js";
 import { createAuth } from "./lib/auth.js";
 import type { AppContext } from "./lib/context.js";

--- a/apps/app/components/auth/auth-error-boundary.tsx
+++ b/apps/app/components/auth/auth-error-boundary.tsx
@@ -1,5 +1,3 @@
-import { getErrorMessage, isUnauthenticatedError } from "#lib/errors";
-import { sessionQueryKey } from "#lib/queries/session";
 import { Button } from "@repo/ui";
 import {
   useQueryClient,
@@ -7,6 +5,9 @@ import {
 } from "@tanstack/react-query";
 import { AlertCircle } from "lucide-react";
 import { ErrorBoundary } from "react-error-boundary";
+
+import { getErrorMessage, isUnauthenticatedError } from "#lib/errors";
+import { sessionQueryKey } from "#lib/queries/session";
 
 interface ResetProps {
   resetErrorBoundary: () => void;

--- a/apps/app/components/auth/auth-form.tsx
+++ b/apps/app/components/auth/auth-form.tsx
@@ -1,8 +1,10 @@
-import { useSocialProviders } from "#lib/queries/config";
 import { Button, Input, cn } from "@repo/ui";
 import { Link } from "@tanstack/react-router";
 import { ArrowLeft, Mail } from "lucide-react";
 import type { ComponentProps, SubmitEvent } from "react";
+
+import { useSocialProviders } from "#lib/queries/config";
+
 import { GoogleLogin } from "./google-login";
 import { OtpVerification } from "./otp-verification";
 import { PasskeyLogin } from "./passkey-login";

--- a/apps/app/components/auth/google-login.tsx
+++ b/apps/app/components/auth/google-login.tsx
@@ -1,8 +1,9 @@
-import { auth } from "#lib/auth";
-import { sessionQueryKey } from "#lib/queries/session";
 import { Button } from "@repo/ui";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+
+import { auth } from "#lib/auth";
+import { sessionQueryKey } from "#lib/queries/session";
 
 interface GoogleLoginProps {
   onError: (error: string | null) => void;

--- a/apps/app/components/auth/otp-verification.tsx
+++ b/apps/app/components/auth/otp-verification.tsx
@@ -1,7 +1,8 @@
-import { auth } from "#lib/auth";
 import { Button, Input } from "@repo/ui";
 import type { SubmitEvent } from "react";
 import { useCallback, useEffect, useState } from "react";
+
+import { auth } from "#lib/auth";
 
 const RESEND_COOLDOWN_SECONDS = 30;
 

--- a/apps/app/components/auth/passkey-login.tsx
+++ b/apps/app/components/auth/passkey-login.tsx
@@ -1,8 +1,9 @@
-import { auth } from "#lib/auth";
-import { authConfig } from "#lib/auth-config";
 import { Button } from "@repo/ui";
 import { KeyRound } from "lucide-react";
 import { useCallback, useState } from "react";
+
+import { auth } from "#lib/auth";
+import { authConfig } from "#lib/auth-config";
 
 interface PasskeyLoginProps {
   onSuccess: () => void;

--- a/apps/app/components/auth/use-auth-form.ts
+++ b/apps/app/components/auth/use-auth-form.ts
@@ -1,6 +1,7 @@
-import { auth } from "#lib/auth";
 import type { SubmitEvent } from "react";
 import { useCallback, useRef, useState } from "react";
+
+import { auth } from "#lib/auth";
 
 type AuthStep = "method" | "email" | "otp";
 

--- a/apps/app/components/layout/header.tsx
+++ b/apps/app/components/layout/header.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@repo/ui";
 import { Menu, X } from "lucide-react";
+
 import { SIDEBAR_ID } from "./constants";
 
 interface HeaderProps {

--- a/apps/app/components/layout/index.tsx
+++ b/apps/app/components/layout/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+
 import { Header } from "./header";
 import { Sidebar } from "./sidebar";
 

--- a/apps/app/components/layout/sidebar-nav.tsx
+++ b/apps/app/components/layout/sidebar-nav.tsx
@@ -1,6 +1,7 @@
-import type { FileRoutesByTo } from "#lib/routeTree.gen";
 import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
+
+import type { FileRoutesByTo } from "#lib/routeTree.gen";
 
 interface SidebarNavItem {
   icon: LucideIcon;

--- a/apps/app/components/layout/sidebar.tsx
+++ b/apps/app/components/layout/sidebar.tsx
@@ -1,4 +1,5 @@
 import { UserMenu } from "#components/user-menu";
+
 import { SIDEBAR_ID, sidebarItems } from "./constants";
 import { SidebarNav } from "./sidebar-nav";
 

--- a/apps/app/components/user-menu.tsx
+++ b/apps/app/components/user-menu.tsx
@@ -1,6 +1,7 @@
-import { useSessionQuery, useSignOut } from "#lib/queries/session";
 import { Avatar, AvatarFallback, Button } from "@repo/ui";
 import { LogOut, RefreshCw, User } from "lucide-react";
+
+import { useSessionQuery, useSignOut } from "#lib/queries/session";
 
 export function UserMenu() {
   const { data: session, isPending, error, refetch } = useSessionQuery();

--- a/apps/app/index.tsx
+++ b/apps/app/index.tsx
@@ -2,11 +2,13 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+
 import { NotFound } from "./components/not-found";
 import { queryClient } from "./lib/query";
 import { routeTree } from "./lib/routeTree.gen";
 import { StoreProvider } from "./lib/store";
 import { ThemeSync } from "./lib/theme";
+
 import "./styles/globals.css";
 
 const router = createRouter({

--- a/apps/app/lib/auth.ts
+++ b/apps/app/lib/auth.ts
@@ -13,6 +13,7 @@ import {
   organizationClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+
 import { authConfig } from "./auth-config";
 
 const baseURL =

--- a/apps/app/lib/edge-routing.test.ts
+++ b/apps/app/lib/edge-routing.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 /**

--- a/apps/app/lib/errors.test.ts
+++ b/apps/app/lib/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import {
   getErrorMessage,
   getErrorStatus,

--- a/apps/app/lib/queries/billing.test.ts
+++ b/apps/app/lib/queries/billing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { billingQueryKey, billingQueryOptions } from "./billing";
 
 describe("billingQueryOptions", () => {

--- a/apps/app/lib/queries/billing.ts
+++ b/apps/app/lib/queries/billing.ts
@@ -7,6 +7,7 @@
  */
 
 import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
+
 import { auth } from "../auth";
 import { trpcClient } from "../trpc";
 

--- a/apps/app/lib/queries/config.ts
+++ b/apps/app/lib/queries/config.ts
@@ -1,4 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
+
 import { trpcClient } from "../trpc";
 
 export const socialProvidersQueryKey = ["config", "socialProviders"] as const;

--- a/apps/app/lib/queries/organization.ts
+++ b/apps/app/lib/queries/organization.ts
@@ -13,6 +13,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
+
 import { auth } from "../auth";
 import { revalidateSession } from "./session";
 

--- a/apps/app/lib/queries/session.test.ts
+++ b/apps/app/lib/queries/session.test.ts
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+
 import {
   getCachedSession,
   isValidSession,

--- a/apps/app/lib/queries/session.ts
+++ b/apps/app/lib/queries/session.ts
@@ -4,7 +4,6 @@
  * UI disagree with the server about who is signed in.
  */
 
-import { getErrorStatus } from "#lib/errors";
 import type { QueryClient } from "@tanstack/react-query";
 import {
   queryOptions,
@@ -12,6 +11,9 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+
+import { getErrorStatus } from "#lib/errors";
+
 import { auth, type Session, type User } from "../auth";
 
 export interface SessionData {

--- a/apps/app/lib/theme.test.tsx
+++ b/apps/app/lib/theme.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import indexHtml from "../index.html?raw";
 import { ThemeSync, useTheme } from "./theme";
 

--- a/apps/app/routes/(app)/index.tsx
+++ b/apps/app/routes/(app)/index.tsx
@@ -1,7 +1,3 @@
-import { useBillingQuery } from "#lib/queries/billing";
-import { useMembersQuery } from "#lib/queries/organization";
-import { useSessionQuery } from "#lib/queries/session";
-import type { FileRoutesByTo } from "#lib/routeTree.gen";
 import {
   Card,
   CardContent,
@@ -11,6 +7,11 @@ import {
 } from "@repo/ui";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { CreditCard, type LucideIcon, Users } from "lucide-react";
+
+import { useBillingQuery } from "#lib/queries/billing";
+import { useMembersQuery } from "#lib/queries/organization";
+import { useSessionQuery } from "#lib/queries/session";
+import type { FileRoutesByTo } from "#lib/routeTree.gen";
 
 export const Route = createFileRoute("/(app)/")({
   component: Dashboard,

--- a/apps/app/routes/(app)/members.tsx
+++ b/apps/app/routes/(app)/members.tsx
@@ -1,9 +1,4 @@
 import {
-  useCreateOrganization,
-  useMembersQuery,
-} from "#lib/queries/organization";
-import { useSessionQuery } from "#lib/queries/session";
-import {
   Avatar,
   AvatarFallback,
   Button,
@@ -18,6 +13,12 @@ import {
 import { createFileRoute } from "@tanstack/react-router";
 import { Building2 } from "lucide-react";
 import { useId, useState } from "react";
+
+import {
+  useCreateOrganization,
+  useMembersQuery,
+} from "#lib/queries/organization";
+import { useSessionQuery } from "#lib/queries/session";
 
 export const Route = createFileRoute("/(app)/members")({
   component: Members,

--- a/apps/app/routes/(app)/route.tsx
+++ b/apps/app/routes/(app)/route.tsx
@@ -1,3 +1,11 @@
+import {
+  createFileRoute,
+  Outlet,
+  redirect,
+  useRouter,
+} from "@tanstack/react-router";
+import { useEffect, type ReactNode } from "react";
+
 import { AuthErrorBoundary } from "#components/auth";
 import { Layout } from "#components/layout";
 import {
@@ -6,13 +14,6 @@ import {
   sessionQueryOptions,
   useSessionQuery,
 } from "#lib/queries/session";
-import {
-  createFileRoute,
-  Outlet,
-  redirect,
-  useRouter,
-} from "@tanstack/react-router";
-import { useEffect, type ReactNode } from "react";
 
 export const Route = createFileRoute("/(app)")({
   // Route-level authentication guard using cache-first strategy.

--- a/apps/app/routes/(app)/settings.tsx
+++ b/apps/app/routes/(app)/settings.tsx
@@ -1,11 +1,4 @@
 import {
-  useBillingPortal,
-  useBillingQuery,
-  useUpgradeSubscription,
-} from "#lib/queries/billing";
-import { useSessionQuery } from "#lib/queries/session";
-import { type ThemePreference, useTheme } from "#lib/theme";
-import {
   Button,
   Card,
   CardContent,
@@ -26,6 +19,14 @@ import {
   Sun,
 } from "lucide-react";
 import { useId } from "react";
+
+import {
+  useBillingPortal,
+  useBillingQuery,
+  useUpgradeSubscription,
+} from "#lib/queries/billing";
+import { useSessionQuery } from "#lib/queries/session";
+import { type ThemePreference, useTheme } from "#lib/theme";
 
 export const Route = createFileRoute("/(app)/settings")({
   component: Settings,

--- a/apps/app/routes/(auth)/login.tsx
+++ b/apps/app/routes/(auth)/login.tsx
@@ -1,11 +1,3 @@
-import { AuthForm } from "#components/auth";
-import { getSafeRedirectUrl } from "#lib/auth-config";
-import { socialProvidersQueryOptions } from "#lib/queries/config";
-import {
-  isValidSession,
-  revalidateSession,
-  sessionQueryOptions,
-} from "#lib/queries/session";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -14,6 +6,15 @@ import {
   useRouter,
 } from "@tanstack/react-router";
 import { z } from "zod";
+
+import { AuthForm } from "#components/auth";
+import { getSafeRedirectUrl } from "#lib/auth-config";
+import { socialProvidersQueryOptions } from "#lib/queries/config";
+import {
+  isValidSession,
+  revalidateSession,
+  sessionQueryOptions,
+} from "#lib/queries/session";
 
 // Sanitize returnTo at parse time - consumers get a safe value or undefined
 const searchSchema = z.object({

--- a/apps/app/routes/(auth)/signup.tsx
+++ b/apps/app/routes/(auth)/signup.tsx
@@ -1,11 +1,3 @@
-import { AuthForm } from "#components/auth";
-import { getSafeRedirectUrl } from "#lib/auth-config";
-import { socialProvidersQueryOptions } from "#lib/queries/config";
-import {
-  isValidSession,
-  revalidateSession,
-  sessionQueryOptions,
-} from "#lib/queries/session";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -14,6 +6,15 @@ import {
   useRouter,
 } from "@tanstack/react-router";
 import { z } from "zod";
+
+import { AuthForm } from "#components/auth";
+import { getSafeRedirectUrl } from "#lib/auth-config";
+import { socialProvidersQueryOptions } from "#lib/queries/config";
+import {
+  isValidSession,
+  revalidateSession,
+  sessionQueryOptions,
+} from "#lib/queries/session";
 
 // Sanitize returnTo at parse time - consumers get a safe value or undefined
 const searchSchema = z.object({

--- a/apps/app/routes/__root.tsx
+++ b/apps/app/routes/__root.tsx
@@ -1,7 +1,8 @@
-import { AppErrorBoundary } from "#components/auth";
-import { Devtools } from "#components/devtools";
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
+
+import { AppErrorBoundary } from "#components/auth";
+import { Devtools } from "#components/devtools";
 
 // Only queryClient in context - needed for beforeLoad prefetching.
 // Auth client is a singleton (no hook equivalent in Better Auth).

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,8 +1,9 @@
-import { tanstackRouter } from "@tanstack/router-plugin/vite";
-import tailwindcss from "@tailwindcss/vite";
-import react from "@vitejs/plugin-react";
 import { TLSSocket } from "node:tls";
 import { URL, fileURLToPath } from "node:url";
+
+import tailwindcss from "@tailwindcss/vite";
+import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import react from "@vitejs/plugin-react";
 import { loadEnv } from "vite";
 import { defineProject } from "vitest/config";
 

--- a/apps/email/templates/email-verification.tsx
+++ b/apps/email/templates/email-verification.tsx
@@ -1,4 +1,5 @@
 import { Button, Heading, Section, Text } from "@react-email/components";
+
 import { BaseTemplate, colors } from "../components/BaseTemplate";
 
 interface EmailVerificationProps {

--- a/apps/email/templates/otp-email.tsx
+++ b/apps/email/templates/otp-email.tsx
@@ -1,4 +1,5 @@
 import { Heading, Section, Text } from "@react-email/components";
+
 import { BaseTemplate, colors } from "../components/BaseTemplate";
 
 interface OTPEmailProps {

--- a/apps/email/templates/password-reset.tsx
+++ b/apps/email/templates/password-reset.tsx
@@ -1,4 +1,5 @@
 import { Button, Heading, Section, Text } from "@react-email/components";
+
 import { BaseTemplate, colors } from "../components/BaseTemplate";
 
 interface PasswordResetProps {

--- a/db/drizzle.config.ts
+++ b/db/drizzle.config.ts
@@ -1,6 +1,7 @@
+import { resolve } from "node:path";
+
 import { configDotenv } from "dotenv";
 import { defineConfig } from "drizzle-kit";
-import { resolve } from "node:path";
 
 // No "test": tests run against PGlite in-process (`@repo/db/testing`), so
 // there is no test connection string to resolve. Leaving the name accepted

--- a/db/index.ts
+++ b/db/index.ts
@@ -6,6 +6,7 @@
 
 import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+
 import * as schema from "./schema";
 
 export * from "./schema";

--- a/db/schema/index.test.ts
+++ b/db/schema/index.test.ts
@@ -10,6 +10,7 @@
 import { createTestDatabase } from "@repo/db/testing";
 import { eq } from "drizzle-orm";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
 import {
   identity,
   invitation,

--- a/db/schema/invitation.ts
+++ b/db/schema/invitation.ts
@@ -2,6 +2,7 @@
 
 import { relations } from "drizzle-orm";
 import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+
 import { generateAuthId } from "./id";
 import { organization } from "./organization";
 import { user } from "./user";

--- a/db/schema/organization.ts
+++ b/db/schema/organization.ts
@@ -2,6 +2,7 @@
 
 import { relations } from "drizzle-orm";
 import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+
 import { generateAuthId } from "./id";
 import { user } from "./user";
 

--- a/db/schema/passkey.ts
+++ b/db/schema/passkey.ts
@@ -9,6 +9,7 @@ import {
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
+
 import { generateAuthId } from "./id";
 import { user } from "./user";
 

--- a/db/schema/subscription.ts
+++ b/db/schema/subscription.ts
@@ -10,6 +10,7 @@ import {
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
+
 import { generateAuthId } from "./id";
 
 export const subscription = pgTable(

--- a/db/schema/user.ts
+++ b/db/schema/user.ts
@@ -23,6 +23,7 @@ import {
   timestamp,
   unique,
 } from "drizzle-orm/pg-core";
+
 import { generateAuthId } from "./id";
 
 /**

--- a/db/scripts/export.ts
+++ b/db/scripts/export.ts
@@ -23,10 +23,11 @@
  * - Script handles concurrent executions without filename conflicts
  */
 
-import { $ } from "bun";
 import { existsSync } from "fs";
 import { chmod, mkdir } from "fs/promises";
 import { resolve } from "path";
+
+import { $ } from "bun";
 
 // Import drizzle config to trigger environment loading and validation
 import "../drizzle.config";

--- a/db/scripts/generate-auth-schema.ts
+++ b/db/scripts/generate-auth-schema.ts
@@ -1,5 +1,6 @@
 import { getAuthTables } from "better-auth/db";
 import type { BetterAuthOptions } from "better-auth/types";
+
 import { createAuth } from "../../apps/api/lib/auth";
 
 /**

--- a/db/scripts/local-database.test.ts
+++ b/db/scripts/local-database.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { isLocalDatabase } from "./local-database";
 
 /**

--- a/db/scripts/seed.ts
+++ b/db/scripts/seed.ts
@@ -6,9 +6,9 @@
 
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+
 import * as schema from "../schema";
 import { seedUsers } from "../seeds/users";
-
 // Import drizzle config to trigger environment loading
 import "../drizzle.config";
 

--- a/db/testing.ts
+++ b/db/testing.ts
@@ -1,11 +1,13 @@
 /** @file In-process PGlite database for tests. */
 
+import { fileURLToPath } from "node:url";
+
 import { PGlite } from "@electric-sql/pglite";
 import { is } from "drizzle-orm";
 import { getTableConfig, PgTable } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
-import { fileURLToPath } from "node:url";
+
 import type { Database } from "./index";
 import * as schema from "./schema";
 

--- a/docs/.vitepress/theme/components/Mermaid.vue
+++ b/docs/.vitepress/theme/components/Mermaid.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from "vue";
 import { useData } from "vitepress";
+import { ref, computed, onMounted, watch } from "vue";
 
 const props = defineProps<{ code: string }>();
 const { isDark } = useData();

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -6,8 +6,10 @@
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 import { h } from "vue";
+
 import GitHubStats from "./components/GitHubStats.vue";
 import Mermaid from "./components/Mermaid.vue";
+
 import "./style.css";
 
 export default {

--- a/docs/adr/005-oxlint-oxfmt.md
+++ b/docs/adr/005-oxlint-oxfmt.md
@@ -33,4 +33,4 @@
 ## Links
 
 - Code/Docs: `.oxlintrc.json`, `.oxfmtrc.json`, `.husky/pre-commit`, [Oxc](https://oxc.rs/)
-- Related ADRs: [ADR-004](/adr/004-typescript-7-native-compiler)
+- Related ADRs: [ADR-004](/adr/004-typescript-7-native-compiler), [ADR-007](/adr/007-oxfmt-sorts-imports)

--- a/docs/adr/007-oxfmt-sorts-imports.md
+++ b/docs/adr/007-oxfmt-sorts-imports.md
@@ -1,0 +1,33 @@
+# ADR-007 Oxfmt owns import order
+
+**Status:** Accepted
+
+**Date:** 2026-09-12 **Tags:** toolchain, formatting, conventions
+
+## Problem
+
+- Import order was owned by `"source.organizeImports": "explicit"` in `.vscode/settings.json`: applied per developer, only to files someone opened in VS Code, and never checked in CI. The result was real inconsistency, not a style preference – `apps/api/lib/app.ts` was sorted because someone edited it, while `packages/ui/components/button.tsx` had `react` out of order because it is shadcn CLI output nobody touched.
+
+## Decision
+
+- `sortImports` in `.oxfmtrc.json` sorts imports, with defaults and nothing else. Oxfmt already formats every file it owns in `bun run format`, checks them in CI, and checks the staged ones on commit, so import order costs no new dependency and no extra pass ([ADR-005](/adr/005-oxlint-oxfmt)).
+- The VS Code code action is removed. `editor.defaultFormatter` is already `oxc.oxc-vscode`, so format-on-save keeps sorting.
+- `internalPattern` is left at its default (`["~/", "@/", "#"]`), which puts `@repo/*` with the externals and `#*` in a group of its own. That distinction is the one [ADR-006](/adr/006-subpath-imports) draws: `@repo/ui` is another package, `#lib/…` is this package's own file.
+- `sortSideEffects` is left off, its default. `db/scripts/seed.ts` imports `../drizzle.config` last to load environment variables before anything reads `DATABASE_URL`; sorting side-effect imports would move it.
+
+## Alternatives (brief)
+
+- **Keep the editor code action** – it is the problem: unenforced, and applied only to files a developer happens to open.
+- **A lint rule** – Oxlint ships no `import/order`, so this means a second tool reporting what the formatter can already fix.
+- **A wider `internalPattern`** – it matches literal prefixes, not globs, so `["@repo/"]` puts workspace packages in the same group as `#*` and loses the package-versus-own-file distinction above.
+
+## Impact
+
+- Positive: import order is deterministic, identical for every developer, and enforced by `bun run format:check`. The one-time reflow touched 74 files.
+- Negative/Risks: `source.organizeImports` also deleted unused imports on save, which Oxfmt does not do. `no-unused-vars` in `.oxlintrc.json` still fails CI on one, so nothing slips through – it surfaces at commit or CI time rather than silently on save, and the diff shows what was removed.
+- A tree-wide reflow conflicts with anything in flight. Import order carries no local identity, so a fork resolving it can take upstream's ordering wholesale.
+
+## Links
+
+- Code/Docs: `.oxfmtrc.json`, `.vscode/settings.json`, `AGENTS.md`, [Oxfmt](https://oxc.rs/docs/guide/usage/formatter)
+- Related ADRs: [ADR-005](/adr/005-oxlint-oxfmt), [ADR-006](/adr/006-subpath-imports)

--- a/packages/ui/components/avatar.tsx
+++ b/packages/ui/components/avatar.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Avatar as AvatarPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/button.tsx
+++ b/packages/ui/components/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/checkbox.tsx
+++ b/packages/ui/components/checkbox.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { CheckIcon } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/dialog.tsx
+++ b/packages/ui/components/dialog.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import { XIcon } from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
+import * as React from "react";
 
-import { cn } from "#lib/utils";
 import { Button } from "#components/button";
+import { cn } from "#lib/utils";
 
 function Dialog({
   ...props

--- a/packages/ui/components/label.tsx
+++ b/packages/ui/components/label.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Label as LabelPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/radio-group.tsx
+++ b/packages/ui/components/radio-group.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { CircleIcon } from "lucide-react";
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/scroll-area.tsx
+++ b/packages/ui/components/scroll-area.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/select.tsx
+++ b/packages/ui/components/select.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/separator.tsx
+++ b/packages/ui/components/separator.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Separator as SeparatorPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/switch.tsx
+++ b/packages/ui/components/switch.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Switch as SwitchPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/components/toggle-group.tsx
+++ b/packages/ui/components/toggle-group.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import { type VariantProps } from "class-variance-authority";
 import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
+import * as React from "react";
 
-import { cn } from "#lib/utils";
 import { toggleVariants } from "#components/toggle";
+import { cn } from "#lib/utils";
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants> & {

--- a/packages/ui/components/toggle.tsx
+++ b/packages/ui/components/toggle.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Toggle as TogglePrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "#lib/utils";
 

--- a/packages/ui/scripts/postprocess.ts
+++ b/packages/ui/scripts/postprocess.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { Glob } from "bun";
 
 const packageDir = join(import.meta.dirname, "..");

--- a/packages/ws-protocol/example.ts
+++ b/packages/ws-protocol/example.ts
@@ -7,6 +7,7 @@
 import { createBunHandler } from "@ws-kit/bun";
 import { memoryPubSub } from "@ws-kit/memory";
 import { withPubSub } from "@ws-kit/pubsub";
+
 import { createAppRouter, Notification } from "./index";
 
 // Create the router with pub/sub support

--- a/packages/ws-protocol/router.ts
+++ b/packages/ws-protocol/router.ts
@@ -26,6 +26,7 @@
  */
 
 import { createRouter, withZod, type Router } from "@ws-kit/zod";
+
 import { Ping, Pong, Echo, GetUser } from "./messages";
 
 /**

--- a/scripts/post-install.ts
+++ b/scripts/post-install.ts
@@ -1,7 +1,8 @@
-import { execa } from "execa";
 import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { EOL } from "node:os";
+
+import { execa } from "execa";
 
 // Create Git-ignored files for environment variable overrides
 if (!existsSync("./.env.local")) {


### PR DESCRIPTION
Import order was owned by `"source.organizeImports": "explicit"` in `.vscode/settings.json` – applied per developer, only to files someone happened to open in VS Code, never checked in CI. The drift was real rather than stylistic: `apps/api/lib/app.ts` was sorted because someone edited it, while `packages/ui/components/button.tsx` had `react` out of order because it is shadcn CLI output nobody touched. Oxfmt already formats every file it owns in `bun run format`, checks them in CI, and checks the staged ones on commit, so moving import order there adds no dependency and no extra pass.

### Changes

| File | Change |
| --- | --- |
| `.oxfmtrc.json` | `"sortImports": true` – defaults, nothing else |
| `.vscode/settings.json` | drop `source.organizeImports`; `editor.defaultFormatter` is already `oxc.oxc-vscode`, so format-on-save still sorts |
| `AGENTS.md` | Oxfmt owns import order – do not reintroduce an editor action or a lint rule |
| `docs/adr/007-oxfmt-sorts-imports.md`<br>`docs/adr/005-oxlint-oxfmt.md` | new ADR, plus a backlink from [ADR-005](https://github.com/kriasoft/react-starter-kit/blob/main/docs/adr/005-oxlint-oxfmt.md) – which claims the Oxc switch "produced no formatting diff", a contract this amends, so the rationale needs a durable home |
| 74 source files | `bun run format` output, nothing hand-edited |

Two defaults are load-bearing and deliberately not overridden:

- **`sortSideEffects` off** – `db/scripts/seed.ts` keeps `import "../drizzle.config"` last, loading env vars before anything reads `DATABASE_URL`. Checked by hand in all four files where a side-effect import's position matters.
- **`internalPattern` untouched** (`["~/", "@/", "#"]`) – keeps `@repo/*` with the externals and `#*` in its own group, the distinction [ADR-006](https://github.com/kriasoft/react-starter-kit/blob/main/docs/adr/006-subpath-imports.md) draws between another package and this package's own file.

### Trade-off

`source.organizeImports` also deleted unused imports on save; Oxfmt does not. `no-unused-vars` still fails CI on one, so nothing slips through – it surfaces at commit or CI time instead of silently on save, with the removal visible in the diff.

### Updating a fork

Sync with the `/merge-seed` skill as usual. Two things are specific to this change:

- **Do not resolve the reflow by hand.** Resolve conflicted hunks on content, then run `bun run format` and let Oxfmt settle import order for both sides. Taking either side wholesale to clear import-order noise drops imports the other side added.
- **ADR numbering may collide.** Local numbering is authoritative, so renumber the incoming ADR-007 and fix its links if the fork already has an `007`.

### Verification

`bun run format:check` · `bun lint` · `bun typecheck` · `bun run test -- --run` (93 passed) · `bun run build` (4 workspaces) – all clean on the final tree.

### Risk

A tree-wide reflow conflicts with anything in flight; rebase open branches right after this lands.

Follow-up to #2184 (TypeScript 7 + Oxc), split out because at 74 files it would have buried that PR's substance.
